### PR TITLE
Remove comment count feature

### DIFF
--- a/layouts/shortcodes/github-prs.html
+++ b/layouts/shortcodes/github-prs.html
@@ -70,11 +70,6 @@
             </div>
           </div>
         </div>
-        <div class="gh-pr-right">
-          ${item.comments ? `<span class="gh-pr-stat" title="Comments">
-            ${icon('icon-comment', 'gh-pr-icon gh-pr-icon--sm')}
-            ${item.comments}
-          </span>` : ''}
         </div>
       </div>`;
     }).join('');


### PR DESCRIPTION
Due to what gemini provide.

If you ever want to add it back accurately, you'd need to call `/repos/{owner}/{repo}/pulls/{number}` per PR to get review_comments, but that's N extra requests, which isn't worth it for a portfolio page.
