### PR TITLE
Fix GitHub social link, add 404 route, switch accent to navy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Footer } from './components/Footer';
 import { Home } from './pages/Home';
 import { BlogList } from './pages/BlogList';
 import { BlogPost } from './pages/BlogPost';
+import { NotFound } from './pages/NotFound';
 import { useActiveSection } from './hooks/useActiveSection';
 import './App.css';
 
@@ -22,6 +23,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/blog" element={<BlogList />} />
             <Route path="/blog/:slug" element={<BlogPost />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </div>
       </main>

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -1,5 +1,5 @@
 .hero {
-  background: linear-gradient(135deg, var(--color-accent) 0%, #e8a07a 45%, var(--color-bg) 100%);
+  background: linear-gradient(135deg, var(--color-accent) 0%, #8fa3c4 45%, var(--color-bg) 100%);
   padding: 64px 32px;
 }
 

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -7,8 +7,8 @@ export const githubUrl = 'https://github.com/guancioul';
 export type SocialIconKey = 'github' | 'email' | 'linkedin' | 'leetcode';
 
 export const socialLinks: { label: string; href: string; icon: SocialIconKey }[] = [
-  { label: 'Website', href: 'https://guancioul.github.io', icon: 'github' },
-  { label: 'Email', href: 'mailto:guancioul@gmail.com', icon: 'email' },
+  { label: 'GitHub', href: githubUrl, icon: 'github' },
+  { label: 'Email', href: `mailto:${email}`, icon: 'email' },
   { label: 'LinkedIn', href: 'https://www.linkedin.com/in/kuan-hao-lai-1869b12ab', icon: 'linkedin' },
   { label: 'LeetCode', href: 'https://leetcode.com/u/guancioul', icon: 'leetcode' },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   --color-text: #2b2722;
   --color-text-muted: #6f6a62;
   --color-border: #ddd8cd;
-  --color-accent: #c1502e;
+  --color-accent: #2a4d8f;
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
 }

--- a/src/pages/NotFound.css
+++ b/src/pages/NotFound.css
@@ -1,0 +1,27 @@
+.not-found {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 96px 32px;
+  text-align: center;
+}
+
+.not-found h1 {
+  font-size: 64px;
+  margin: 0 0 8px;
+  color: var(--color-accent);
+}
+
+.not-found p {
+  color: var(--color-text-muted);
+  margin: 0 0 24px;
+}
+
+.not-found__link {
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.not-found__link:hover {
+  color: var(--color-accent);
+}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom';
+import './NotFound.css';
+
+export function NotFound() {
+  return (
+    <div className="not-found">
+      <h1>404</h1>
+      <p>Page not found.</p>
+      <Link to="/" className="not-found__link">
+        ← Back home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #28
Closes #29

- socialLinks "Website" entry now points to githubUrl and is labeled "GitHub"; Email entry reuses the email constant instead of a hardcoded duplicate string
- Add a catch-all "*" route rendering a new NotFound page for unmatched hash paths
- Swap --color-accent from terracotta to navy blue (#2a4d8f) and retune the Hero gradient's mid-stop to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)