### PR TITLE
Fix low-contrast icons in dark mode

### DIFF
--- a/src/components/SocialBadges.css
+++ b/src/components/SocialBadges.css
@@ -35,6 +35,10 @@
   --badge-color: #1f2328;
 }
 
+:root[data-theme='dark'] .social-badge--github {
+  --badge-color: #f0f6fc;
+}
+
 .social-badge--email {
   --badge-color: #d14836;
 }

--- a/src/pages/Skills.css
+++ b/src/pages/Skills.css
@@ -48,6 +48,10 @@
   background: var(--color-bg);
 }
 
+:root[data-theme='dark'] .skill-tag__icon--invert {
+  filter: invert(1);
+}
+
 .skill-panel__row--cert {
   flex-direction: row;
   align-items: center;

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -7,6 +7,10 @@ import './Skills.css';
 
 const techGroups = [...techStack, ...additionalSkills];
 
+// These icons are solid black SVGs with no theme-aware coloring, so they need
+// to be inverted in dark mode to stay visible against the dark background.
+const BLACK_FILL_ICONS = new Set(['Rust', 'Next.js']);
+
 export function Skills() {
   return (
     <section id="skills" className="page">
@@ -25,7 +29,15 @@ export function Skills() {
                   const iconUrl = techIconUrl(tag);
                   return (
                     <span className="skill-tag mono" key={tag}>
-                      {iconUrl && <img src={iconUrl} alt="" width={14} height={14} />}
+                      {iconUrl && (
+                        <img
+                          src={iconUrl}
+                          alt=""
+                          width={14}
+                          height={14}
+                          className={BLACK_FILL_ICONS.has(tag) ? 'skill-tag__icon--invert' : undefined}
+                        />
+                      )}
                       {tag}
                     </span>
                   );


### PR DESCRIPTION
## Summary
- The GitHub social badge's hover color (`#1f2328`) was near-black, so it nearly disappeared against the dark surface in dark mode — added a `:root[data-theme='dark']` override using a lighter GitHub-ish gray.
- The **Rust** and **Next.js** tech icons in the Skills page are solid-black SVGs (`fill="#000000"`, no theme-aware coloring) rendered via `<img>`, so they were invisible in dark mode — added a `skill-tag__icon--invert` class that applies `filter: invert(1)` for just those two icons in dark mode.

## Test plan
- [x] `tsc --noEmit`, `eslint src`, `markdownlint-cli2`, and `npm run build` all pass clean
- [x] Toggle dark mode and check the GitHub badge hover state and the Rust/Next.js icons in the Skills section

🤖 Generated with [Claude Code](https://claude.com/claude-code)