### PR TITLE
Add Travel page with shared markdown image embeds

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,7 +1,8 @@
 {
   "config": {
     "default": true,
-    "MD013": false
+    "MD013": false,
+    "MD033": { "allowed_elements": ["div", "img"] }
   },
   "ignores": ["node_modules", "dist"]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Personal site, built as a React + Vite single-page app and deployed to GitHub Pa
 
 ## What it looks like
 
-Warm beige background (`#efece6`), Inter for body text, JetBrains Mono for code/repo labels. A sticky header with nav links smooth-scrolls within the home page, and a "Blog" link routes to a separate page.
+Warm beige background (`#efece6`), Inter for body text, JetBrains Mono for code/repo labels. A sticky header with nav links smooth-scrolls within the home page, and "Blog"/"Challenges"/"Travel" links route to separate pages. A dark mode toggle in the header swaps the theme via `data-theme="dark"` on `<html>`, persisted to `localStorage` and defaulting to `prefers-color-scheme`.
 
 ### Home (`/`)
 
@@ -19,6 +19,24 @@ A single scrolling page with a fixed scroll-spy dot nav:
 Posts are Markdown files in `src/content/posts/*.md` with frontmatter (`title`, `date`, `summary`), rendered via `marked`. Routing uses `HashRouter` since the site is static GitHub Pages hosting with no server-side rewrites.
 
 Both the GitHub and CNCF widgets cache their responses in `localStorage` (10 min and 6 hr TTL respectively) so repeat visits don't re-hit the APIs.
+
+### Challenges (`/challenges`, `/challenges/:slug`, `/challenges/:slug/:date`)
+
+Personal habit/discipline challenges (e.g. "Project 50", "Dopamine Detox"). Each challenge lives at `src/content/challenges/<slug>/meta.md` (frontmatter: `title`, `image`, `startDate`, `endDate`, `targetDays`, `tags`, `summary`) with daily entries in `src/content/challenges/<slug>/entries/*.md` (frontmatter: `date`, `title`; body is that day's notes, often a `## Checklist` of markdown checkboxes). The list page shows a progress bar (`entries.length / targetDays`); each entry links to its own page. A sibling `template.md` per challenge (outside the glob patterns `lib/challenges.ts` reads, so it's never picked up as real content) is a copy-paste starting point for new days.
+
+### Travel (`/travel`, `/travel/:slug`)
+
+Trip write-ups. Each trip is `src/content/travel/<slug>/meta.md` (frontmatter: `title`, `cover`, `location`, `startDate`, `endDate`, `tags`, `summary`, optional `hidden: true` to unlist it from `/travel` while keeping the direct URL reachable). The body is freeform markdown — embed photos inline wherever they belong in the prose using the shared markdown content embeds described below.
+
+### Markdown content embeds
+
+Available in any markdown body rendered via `dangerouslySetInnerHTML` (blog posts, challenge entries, travel write-ups) — the CSS lives in `src/index.css`, the interactive behavior is wired up by `src/hooks/useMarkdownEmbeds.ts`, called from each page's `BlogPost.tsx` / `ChallengeEntry.tsx` / `TravelDetail.tsx`:
+
+- **`<div class="md-gallery"><img src="..."> ...</div>`** — a masonry grid (CSS multi-column, default 3 columns; override with `data-columns="2"`). Clicking a photo grows it in place to a centered preview (FLIP animation from the clicked thumbnail's on-screen position) while the rest of the gallery dims; closes on an outside click or `Escape`.
+- **`<div class="md-carousel"><img src="..."> ...</div>`** — a slideshow that auto-advances only while scrolled into view (pauses out of view), with prev/next buttons and swipe/drag support for manual navigation.
+- **`<div class="md-full-bleed"><img src="..."></div>`** — a full viewport-width image (pure CSS breakout, no JS), uncropped (`height: auto`).
+
+`.md-gallery` and `.md-carousel` also break out wider than the narrow text column (`width: min(950px, 92vw)`, centered) rather than sitting at the same width as body text, collapsing back to the column width on mobile.
 
 ## Run it locally
 
@@ -39,11 +57,12 @@ npm run lint:md     # markdownlint
 ```text
 src/
   data/        profile + highlights content (typed, no CMS)
-  content/     blog posts (markdown + frontmatter)
-  lib/         localStorage cache helper, markdown/frontmatter parsing, post loading
-  components/  Header, Hero, Footer, ScrollDots, Highlights, DevStat, GithubContributions, ...
-  pages/       Home, About, OpenSource, BlogList, BlogPost
-  App.tsx      route table (/, /blog, /blog/:slug)
+  content/     blog posts, challenges, and travel write-ups (markdown + frontmatter)
+  hooks/       useTheme (dark mode), useMarkdownEmbeds (gallery/carousel behavior), ...
+  lib/         localStorage cache helper, markdown/frontmatter parsing, posts/challenges/travel loading
+  components/  Header, Hero, Footer, ScrollDots, Highlights, DevStat, GithubContributions, ThemeIcons, ...
+  pages/       Home, About, OpenSource, BlogList, BlogPost, Challenges, ChallengeDetail, ChallengeEntry, Travel, TravelDetail
+  App.tsx      route table (/, /blog, /blog/:slug, /challenges, /challenges/:slug, /challenges/:slug/:date, /travel, /travel/:slug)
 ```
 
 See `CLAUDE.md` / `AGENTS.md` for more detail on the architecture.

--- a/public/assets/travel/kyoto-autumn.svg
+++ b/public/assets/travel/kyoto-autumn.svg
@@ -1,0 +1,15 @@
+<svg width="800" height="450" viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="450" fill="#efece6"/>
+  <g stroke="#ddd8cd" stroke-width="1">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="180" x2="800" y2="180"/>
+    <line x1="0" y1="270" x2="800" y2="270"/>
+    <line x1="0" y1="360" x2="800" y2="360"/>
+  </g>
+  <g transform="translate(550,150)" fill="none" stroke="#2a4d8f" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 120 L60 0 L120 120 Z"/>
+    <path d="M40 120 L90 30 L140 120 Z"/>
+  </g>
+  <text x="60" y="270" font-family="JetBrains Mono, monospace" font-size="48" font-weight="700" fill="#2a4d8f">KYOTO</text>
+  <text x="60" y="340" font-family="Inter, sans-serif" font-size="28" font-weight="600" fill="#2b2722">AUTUMN TRIP</text>
+</svg>

--- a/public/assets/travel/kyoto-autumn/01-bamboo-grove.svg
+++ b/public/assets/travel/kyoto-autumn/01-bamboo-grove.svg
@@ -1,0 +1,11 @@
+<svg width="600" height="420" viewBox="0 0 600 420" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="420" fill="#efece6"/>
+  <g stroke="#2a4d8f" stroke-width="8" stroke-linecap="round">
+    <line x1="80" y1="0" x2="80" y2="420"/>
+    <line x1="180" y1="0" x2="180" y2="420"/>
+    <line x1="280" y1="0" x2="280" y2="420"/>
+    <line x1="380" y1="0" x2="380" y2="420"/>
+    <line x1="480" y1="0" x2="480" y2="420"/>
+  </g>
+  <text x="40" y="380" font-family="Inter, sans-serif" font-size="20" font-weight="600" fill="#2b2722">Arashiyama Bamboo Grove</text>
+</svg>

--- a/public/assets/travel/kyoto-autumn/02-fushimi-inari.svg
+++ b/public/assets/travel/kyoto-autumn/02-fushimi-inari.svg
@@ -1,0 +1,9 @@
+<svg width="600" height="860" viewBox="0 0 600 860" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="860" fill="#efece6"/>
+  <g fill="none" stroke="#a23b2e" stroke-width="14">
+    <path d="M100 250 H500 M120 190 V330 M480 190 V330"/>
+    <path d="M150 430 H450 M170 370 V510 M430 370 V510"/>
+    <path d="M180 610 H420 M195 560 V680 M405 560 V680"/>
+  </g>
+  <text x="40" y="800" font-family="Inter, sans-serif" font-size="24" font-weight="600" fill="#2b2722">Fushimi Inari at Sunrise</text>
+</svg>

--- a/public/assets/travel/kyoto-autumn/03-tofukuji-maples.svg
+++ b/public/assets/travel/kyoto-autumn/03-tofukuji-maples.svg
@@ -1,0 +1,11 @@
+<svg width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="600" fill="#efece6"/>
+  <g fill="#a23b2e">
+    <circle cx="160" cy="180" r="60"/>
+    <circle cx="300" cy="120" r="80"/>
+    <circle cx="450" cy="200" r="70"/>
+    <circle cx="220" cy="280" r="55"/>
+    <circle cx="380" cy="300" r="65"/>
+  </g>
+  <text x="40" y="560" font-family="Inter, sans-serif" font-size="22" font-weight="600" fill="#2b2722">Tofuku-ji Maples</text>
+</svg>

--- a/public/assets/travel/kyoto-autumn/04-ryokan-room.svg
+++ b/public/assets/travel/kyoto-autumn/04-ryokan-room.svg
@@ -1,0 +1,7 @@
+<svg width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="600" fill="#efece6"/>
+  <rect x="60" y="60" width="480" height="480" fill="none" stroke="#ddd8cd" stroke-width="6"/>
+  <rect x="120" y="380" width="360" height="140" rx="8" fill="#f8f6f1" stroke="#2b2722" stroke-width="4"/>
+  <rect x="160" y="160" width="280" height="160" fill="#f8f6f1" stroke="#2b2722" stroke-width="4"/>
+  <text x="40" y="560" font-family="Inter, sans-serif" font-size="22" font-weight="600" fill="#2b2722">Ryokan Room in Higashiyama</text>
+</svg>

--- a/public/assets/travel/kyoto-autumn/05-street-food.svg
+++ b/public/assets/travel/kyoto-autumn/05-street-food.svg
@@ -1,0 +1,7 @@
+<svg width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="600" fill="#efece6"/>
+  <circle cx="300" cy="260" r="160" fill="#f8f6f1" stroke="#2b2722" stroke-width="4"/>
+  <circle cx="300" cy="260" r="100" fill="none" stroke="#a23b2e" stroke-width="6"/>
+  <circle cx="300" cy="260" r="40" fill="#2a4d8f"/>
+  <text x="40" y="560" font-family="Inter, sans-serif" font-size="22" font-weight="600" fill="#2b2722">Matcha &amp; Konbini Snacks</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { BlogPost } from './pages/BlogPost';
 import { Challenges } from './pages/Challenges';
 import { ChallengeDetail } from './pages/ChallengeDetail';
 import { ChallengeEntry } from './pages/ChallengeEntry';
+import { Travel } from './pages/Travel';
+import { TravelDetail } from './pages/TravelDetail';
 import { NotFound } from './pages/NotFound';
 import { useActiveSection } from './hooks/useActiveSection';
 import './App.css';
@@ -44,6 +46,8 @@ function App() {
             <Route path="/challenges" element={<Challenges />} />
             <Route path="/challenges/:slug" element={<ChallengeDetail />} />
             <Route path="/challenges/:slug/:date" element={<ChallengeEntry />} />
+            <Route path="/travel" element={<Travel />} />
+            <Route path="/travel/:slug" element={<TravelDetail />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,6 +20,7 @@ export function Header({ activeSection }: { activeSection: string }) {
   const isHome = location.pathname === '/';
   const isBlog = location.pathname.startsWith('/blog');
   const isChallenges = location.pathname.startsWith('/challenges');
+  const isTravel = location.pathname.startsWith('/travel');
 
   function handleSectionClick(id: string) {
     setMenuOpen(false);
@@ -79,6 +80,13 @@ export function Header({ activeSection }: { activeSection: string }) {
           onClick={() => setMenuOpen(false)}
         >
           Challenges
+        </Link>
+        <Link
+          to="/travel"
+          className={`site-header__link${isTravel ? ' site-header__link--active' : ''}`}
+          onClick={() => setMenuOpen(false)}
+        >
+          Travel
         </Link>
         <button
           type="button"

--- a/src/content/travel/kyoto-autumn/meta.md
+++ b/src/content/travel/kyoto-autumn/meta.md
@@ -1,0 +1,38 @@
+---
+title: Kyoto in Autumn
+cover: /assets/travel/kyoto-autumn.svg
+location: Kyoto, Japan
+startDate: 2025-11-10
+endDate: 2025-11-15
+tags: Japan, Solo Trip, Hiking
+summary: Five days chasing fall colors through Kyoto's temples, bamboo groves, and back streets.
+hidden: true
+---
+Spent five days in Kyoto right at the peak of koyo season. Stayed in a small ryokan near Higashiyama and mostly got around on foot and by bus.
+
+## Highlights
+
+- Early-morning walk through Arashiyama's bamboo grove before the crowds showed up
+- Fushimi Inari at sunrise — empty torii gates all the way up
+- Way too much matcha and konbini food, no regrets
+
+<div class="md-gallery" data-columns="3">
+  <img src="/assets/travel/kyoto-autumn/01-bamboo-grove.svg" alt="Arashiyama Bamboo Grove">
+  <img src="/assets/travel/kyoto-autumn/03-tofukuji-maples.svg" alt="Tofuku-ji Maples">
+  <img src="/assets/travel/kyoto-autumn/02-fushimi-inari.svg" alt="Fushimi Inari at Sunrise">
+  <img src="/assets/travel/kyoto-autumn/04-ryokan-room.svg" alt="Ryokan Room in Higashiyama">
+  <img src="/assets/travel/kyoto-autumn/05-street-food.svg" alt="Matcha and Konbini Snacks">
+</div>
+
+> The maple trees at Tofuku-ji were worth the early alarm — completely covered in red by mid-November.
+
+<div class="md-carousel">
+  <img src="/assets/travel/kyoto-autumn/03-tofukuji-maples.svg" alt="Tofuku-ji Maples">
+  <img src="/assets/travel/kyoto-autumn/05-street-food.svg" alt="Matcha and Konbini Snacks">
+</div>
+
+<div class="md-full-bleed">
+  <img src="/assets/travel/kyoto-autumn.svg" alt="Kyoto skyline">
+</div>
+
+Would go back in a heartbeat, ideally for a full week next time so there's room to slow down.

--- a/src/hooks/useMarkdownEmbeds.ts
+++ b/src/hooks/useMarkdownEmbeds.ts
@@ -1,0 +1,236 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+const CAROUSEL_INTERVAL_MS = 4000;
+const SWIPE_THRESHOLD_PX = 40;
+
+function setActiveSlide(slides: HTMLImageElement[], dots: HTMLElement[], index: number) {
+  slides.forEach((slide, i) => slide.classList.toggle('is-active', i === index));
+  dots.forEach((dot, i) => dot.classList.toggle('is-active', i === index));
+}
+
+function enhanceCarousels(root: HTMLElement) {
+  root.querySelectorAll<HTMLDivElement>('.md-carousel').forEach((carousel) => {
+    if (carousel.dataset.enhanced) return;
+    carousel.dataset.enhanced = 'true';
+
+    const slides = Array.from(carousel.querySelectorAll('img'));
+    if (slides.length === 0) return;
+
+    slides.forEach((slide, i) => slide.classList.toggle('is-active', i === 0));
+    if (slides.length < 2) return;
+
+    const dotsRow = document.createElement('div');
+    dotsRow.className = 'md-carousel__dots';
+    dotsRow.append(
+      ...slides.map((_, i) => {
+        const dot = document.createElement('span');
+        dot.className = `md-carousel__dot${i === 0 ? ' is-active' : ''}`;
+        return dot;
+      }),
+    );
+
+    const prevButton = document.createElement('button');
+    prevButton.type = 'button';
+    prevButton.className = 'md-carousel__nav md-carousel__nav--prev';
+    prevButton.setAttribute('aria-label', 'Previous photo');
+    prevButton.textContent = '←';
+
+    const nextButton = document.createElement('button');
+    nextButton.type = 'button';
+    nextButton.className = 'md-carousel__nav md-carousel__nav--next';
+    nextButton.setAttribute('aria-label', 'Next photo');
+    nextButton.textContent = '→';
+
+    carousel.append(dotsRow, prevButton, nextButton);
+
+    const dots = Array.from(dotsRow.children) as HTMLElement[];
+    let index = 0;
+    let timer: number | null = null;
+    let inView = false;
+
+    function goTo(nextIndex: number) {
+      index = (nextIndex + slides.length) % slides.length;
+      setActiveSlide(slides, dots, index);
+    }
+
+    function stop() {
+      if (timer === null) return;
+      window.clearInterval(timer);
+      timer = null;
+    }
+
+    function start() {
+      stop();
+      if (!inView) return;
+      timer = window.setInterval(() => goTo(index + 1), CAROUSEL_INTERVAL_MS);
+    }
+
+    function manualGoTo(nextIndex: number) {
+      goTo(nextIndex);
+      start();
+    }
+
+    prevButton.addEventListener('click', () => manualGoTo(index - 1));
+    nextButton.addEventListener('click', () => manualGoTo(index + 1));
+
+    let dragStartX: number | null = null;
+
+    carousel.addEventListener('pointerdown', (event) => {
+      dragStartX = event.clientX;
+    });
+    carousel.addEventListener('pointerup', (event) => {
+      if (dragStartX === null) return;
+      const delta = event.clientX - dragStartX;
+      dragStartX = null;
+      if (Math.abs(delta) < SWIPE_THRESHOLD_PX) return;
+      manualGoTo(delta < 0 ? index + 1 : index - 1);
+    });
+    carousel.addEventListener('pointerleave', () => {
+      dragStartX = null;
+    });
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        inView = entry.isIntersecting;
+        if (inView) start();
+        else stop();
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(carousel);
+  });
+}
+
+interface Lightbox {
+  show(image: HTMLImageElement, gallery: HTMLElement): void;
+}
+
+let sharedLightbox: Lightbox | null = null;
+
+const FLIGHT_MS = 380;
+
+/** The rect a photo should grow to: centered, scaled to fit the viewport while keeping its natural aspect ratio. */
+function targetRect(naturalWidth: number, naturalHeight: number) {
+  const maxWidth = window.innerWidth * 0.9;
+  const maxHeight = window.innerHeight * 0.85;
+  const scale = Math.min(maxWidth / naturalWidth, maxHeight / naturalHeight);
+  const width = naturalWidth * scale;
+  const height = naturalHeight * scale;
+  return {
+    top: (window.innerHeight - height) / 2,
+    left: (window.innerWidth - width) / 2,
+    width,
+    height,
+  };
+}
+
+function placeStage(stage: HTMLElement, rect: { top: number; left: number; width: number; height: number }) {
+  stage.style.top = `${rect.top}px`;
+  stage.style.left = `${rect.left}px`;
+  stage.style.width = `${rect.width}px`;
+  stage.style.height = `${rect.height}px`;
+}
+
+function createLightbox(): Lightbox {
+  const overlay = document.createElement('div');
+  overlay.className = 'md-lightbox';
+
+  const stage = document.createElement('img');
+  stage.className = 'md-lightbox__photo';
+
+  overlay.append(stage);
+  document.body.append(overlay);
+
+  let currentImage: HTMLImageElement | null = null;
+  let activeGallery: HTMLElement | null = null;
+  let closing = false;
+
+  function flyTo(naturalWidth: number, naturalHeight: number) {
+    stage.style.transition = `top ${FLIGHT_MS}ms ease, left ${FLIGHT_MS}ms ease, width ${FLIGHT_MS}ms ease, height ${FLIGHT_MS}ms ease`;
+    placeStage(stage, targetRect(naturalWidth, naturalHeight));
+  }
+
+  function close() {
+    if (closing || !currentImage) return;
+    closing = true;
+    overlay.classList.remove('is-open');
+    activeGallery?.classList.remove('md-gallery--dimmed');
+
+    const origin = currentImage.getBoundingClientRect();
+    stage.style.transition = `top ${FLIGHT_MS}ms ease, left ${FLIGHT_MS}ms ease, width ${FLIGHT_MS}ms ease, height ${FLIGHT_MS}ms ease, opacity ${FLIGHT_MS}ms ease`;
+    placeStage(stage, origin);
+    stage.style.opacity = '0';
+
+    window.setTimeout(() => {
+      stage.removeAttribute('style');
+      currentImage = null;
+      activeGallery = null;
+      closing = false;
+    }, FLIGHT_MS);
+  }
+
+  function show(image: HTMLImageElement, gallery: HTMLElement) {
+    closing = false;
+    currentImage = image;
+    activeGallery = gallery;
+
+    const origin = image.getBoundingClientRect();
+    stage.src = image.src;
+    stage.style.transition = 'none';
+    stage.style.opacity = '1';
+    placeStage(stage, origin);
+
+    gallery.classList.add('md-gallery--dimmed');
+    overlay.classList.add('is-open');
+
+    // Force layout so the browser registers the origin rect before flying to the target rect.
+    void stage.offsetWidth;
+    flyTo(image.naturalWidth, image.naturalHeight);
+  }
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) close();
+  });
+  document.addEventListener('keydown', (event) => {
+    if (overlay.classList.contains('is-open') && event.key === 'Escape') close();
+  });
+
+  return { show };
+}
+
+function getLightbox(): Lightbox {
+  sharedLightbox ??= createLightbox();
+  return sharedLightbox;
+}
+
+function enhanceGalleries(root: HTMLElement) {
+  root.querySelectorAll<HTMLDivElement>('.md-gallery').forEach((gallery) => {
+    if (gallery.dataset.enhanced) return;
+    gallery.dataset.enhanced = 'true';
+
+    if (gallery.dataset.columns) {
+      gallery.style.setProperty('--md-gallery-columns', gallery.dataset.columns);
+    }
+
+    gallery.querySelectorAll('img').forEach((image) => {
+      image.addEventListener('click', () => getLightbox().show(image, gallery));
+    });
+  });
+}
+
+/**
+ * Wires up the interactive behavior for markdown content embeds rendered via
+ * dangerouslySetInnerHTML: `.md-carousel` auto-advances while in view and can
+ * also be swiped or stepped with its prev/next buttons; `.md-gallery` photos
+ * open a click-to-zoom preview that closes on an outside click or Escape.
+ * `.md-full-bleed` needs no JS — it's pure CSS.
+ */
+export function useMarkdownEmbeds(ref: RefObject<HTMLElement | null>, ...deps: unknown[]) {
+  useEffect(() => {
+    if (!ref.current) return;
+    enhanceCarousels(ref.current);
+    enhanceGalleries(ref.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -59,3 +59,172 @@ h3 {
 button {
   font-family: inherit;
 }
+
+/* Markdown content embeds — usable in any markdown body rendered via
+   dangerouslySetInnerHTML (blog posts, challenge entries, travel write-ups),
+   wired up by the useMarkdownEmbeds hook:
+   <div class="md-gallery" data-columns="2"><img src="..."> ...</div> —
+     masonry grid (default 3 columns, override with data-columns), click a
+     photo to open a zoomed preview; click outside it (or Escape) to close.
+   <div class="md-carousel"><img src="..."> ...</div> — auto-advancing
+     slideshow that only plays while scrolled into view, with prev/next
+     buttons and swipe/drag support for manual navigation.
+   <div class="md-full-bleed"><img src="..."></div> — full viewport-width
+     image, pure CSS, no JS needed. */
+
+.md-gallery {
+  column-count: var(--md-gallery-columns, 3);
+  column-gap: 10px;
+  width: min(950px, 92vw);
+  margin-top: 0;
+  margin-bottom: 16px;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  transition: opacity 0.3s ease;
+}
+
+.md-gallery img {
+  display: block;
+  width: 100%;
+  margin: 0 0 10px;
+  border-radius: 8px;
+  background: var(--color-border);
+  cursor: zoom-in;
+  break-inside: avoid;
+}
+
+.md-gallery--dimmed img {
+  opacity: 0.12;
+  transition: opacity 0.3s ease;
+}
+
+.md-carousel {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--color-border);
+  width: min(950px, 92vw);
+  margin-top: 0;
+  margin-bottom: 16px;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  cursor: grab;
+  touch-action: pan-y;
+  user-select: none;
+}
+
+.md-carousel img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.8s ease;
+}
+
+.md-carousel img.is-active {
+  opacity: 1;
+}
+
+.md-carousel__dots {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  z-index: 1;
+}
+
+.md-carousel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.md-carousel__dot.is-active {
+  background: #fff;
+}
+
+.md-carousel__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+  z-index: 1;
+}
+
+.md-carousel__nav:hover {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.md-carousel__nav--prev {
+  left: 12px;
+}
+
+.md-carousel__nav--next {
+  right: 12px;
+}
+
+.md-full-bleed {
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  margin-bottom: 16px;
+}
+
+.md-full-bleed img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.md-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+}
+
+.md-lightbox.is-open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.md-lightbox__photo {
+  position: fixed;
+  border-radius: 6px;
+  object-fit: cover;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+@media (max-width: 768px) {
+  .md-gallery,
+  .md-carousel {
+    width: 100%;
+    margin-left: 0;
+    transform: none;
+  }
+
+  .md-gallery {
+    column-count: 2;
+  }
+}

--- a/src/lib/travel.ts
+++ b/src/lib/travel.ts
@@ -1,0 +1,54 @@
+import { parseFrontmatter } from './markdown';
+
+export interface Trip {
+  slug: string;
+  title: string;
+  cover: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  tags: string[];
+  summary: string;
+  content: string;
+  hidden: boolean;
+}
+
+const metaModules = import.meta.glob('../content/travel/*/meta.md', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+
+function slugFromMetaPath(path: string): string {
+  return path.split('/').slice(-2, -1)[0];
+}
+
+const trips: Trip[] = Object.entries(metaModules)
+  .map(([path, raw]) => {
+    const slug = slugFromMetaPath(path);
+    const { data, content } = parseFrontmatter(raw);
+
+    return {
+      slug,
+      title: data.title ?? slug,
+      cover: data.cover ?? '',
+      location: data.location ?? '',
+      startDate: data.startDate ?? '',
+      endDate: data.endDate ?? '',
+      tags: data.tags
+        ? data.tags.split(',').map((tag) => tag.trim()).filter(Boolean)
+        : [],
+      summary: data.summary ?? '',
+      content,
+      hidden: data.hidden === 'true',
+    };
+  })
+  .sort((a, b) => (a.startDate < b.startDate ? 1 : -1));
+
+export function getAllTrips(): Trip[] {
+  return trips.filter((t) => !t.hidden);
+}
+
+export function getTripBySlug(slug: string): Trip | undefined {
+  return trips.find((t) => t.slug === slug);
+}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,11 +1,16 @@
+import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { renderMarkdown } from '../lib/markdown';
 import { getPostBySlug } from '../lib/posts';
+import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import './BlogPost.css';
 
 export function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
   const post = slug ? getPostBySlug(slug) : undefined;
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useMarkdownEmbeds(bodyRef, post?.content);
 
   if (!post) {
     return (
@@ -36,7 +41,11 @@ export function BlogPost() {
           </div>
         )}
       </div>
-      <div className="blog-post__body" dangerouslySetInnerHTML={{ __html: renderMarkdown(post.content) }} />
+      <div
+        ref={bodyRef}
+        className="blog-post__body"
+        dangerouslySetInnerHTML={{ __html: renderMarkdown(post.content) }}
+      />
     </div>
   );
 }

--- a/src/pages/ChallengeEntry.tsx
+++ b/src/pages/ChallengeEntry.tsx
@@ -1,12 +1,17 @@
+import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { renderMarkdown } from '../lib/markdown';
 import { getChallengeBySlug } from '../lib/challenges';
+import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import './ChallengeEntry.css';
 
 export function ChallengeEntry() {
   const { slug, date } = useParams<{ slug: string; date: string }>();
   const challenge = slug ? getChallengeBySlug(slug) : undefined;
   const entry = challenge?.entries.find((e) => e.date === date);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useMarkdownEmbeds(bodyRef, entry?.content);
 
   if (!challenge || !entry) {
     return (
@@ -32,6 +37,7 @@ export function ChallengeEntry() {
       <h1 className="challenge-entry-page__title">{entry.title}</h1>
       <span className="challenge-entry-page__date mono">{entry.date}</span>
       <div
+        ref={bodyRef}
         className="challenge-entry-page__body"
         dangerouslySetInnerHTML={{ __html: renderMarkdown(entry.content) }}
       />

--- a/src/pages/Travel.css
+++ b/src/pages/Travel.css
@@ -1,0 +1,108 @@
+.travel {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 72px 32px;
+}
+
+.travel h1 {
+  font-size: 32px;
+  margin: 0 0 40px;
+}
+
+.travel__empty {
+  color: var(--color-text-muted);
+}
+
+.travel__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+}
+
+.trip-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.trip-card:hover {
+  border-color: var(--color-accent);
+  transform: translateY(-2px);
+}
+
+.trip-card__image {
+  height: 160px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--color-border);
+}
+
+.trip-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 18px 20px 20px;
+  gap: 8px;
+}
+
+.trip-card__title {
+  font-size: 18px;
+  margin: 0;
+}
+
+.trip-card__meta-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.trip-card__location {
+  font-size: 13px;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.trip-card__dates {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.trip-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.trip-card__tag {
+  font-size: 11px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.trip-card__summary {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .travel {
+    padding: 48px 20px;
+  }
+
+  .travel__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/Travel.tsx
+++ b/src/pages/Travel.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import { getAllTrips } from '../lib/travel';
+import './Travel.css';
+
+export function Travel() {
+  const trips = getAllTrips();
+
+  return (
+    <div className="travel">
+      <h1>Travel</h1>
+
+      {trips.length === 0 ? (
+        <p className="travel__empty">No trips logged yet.</p>
+      ) : (
+        <div className="travel__grid">
+          {trips.map((trip) => (
+            <Link to={`/travel/${trip.slug}`} className="trip-card" key={trip.slug}>
+              {trip.cover && (
+                <div className="trip-card__image" style={{ backgroundImage: `url(${trip.cover})` }} />
+              )}
+              <div className="trip-card__body">
+                <h2 className="trip-card__title">{trip.title}</h2>
+                <div className="trip-card__meta-row">
+                  {trip.location && <span className="trip-card__location">{trip.location}</span>}
+                  <span className="trip-card__dates mono">
+                    {trip.startDate}
+                    {trip.endDate ? ` – ${trip.endDate}` : ''}
+                  </span>
+                </div>
+                {trip.tags.length > 0 && (
+                  <div className="trip-card__tags">
+                    {trip.tags.map((tag) => (
+                      <span className="trip-card__tag mono" key={tag}>
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <p className="trip-card__summary">{trip.summary}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/TravelDetail.css
+++ b/src/pages/TravelDetail.css
@@ -1,0 +1,95 @@
+.travel-detail {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 72px 32px;
+}
+
+.travel-detail__back {
+  display: inline-block;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 24px;
+}
+
+.travel-detail__back:hover {
+  color: var(--color-accent);
+}
+
+.travel-detail__cover {
+  height: 280px;
+  border-radius: 10px;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--color-border);
+  margin-bottom: 24px;
+}
+
+.travel-detail__title {
+  font-size: 32px;
+  margin: 0 0 8px;
+}
+
+.travel-detail__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.travel-detail__location {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.travel-detail__dates {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.travel-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.travel-detail__tag {
+  font-size: 11px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.travel-detail__body h2 {
+  font-size: 22px;
+  margin: 32px 0 12px;
+}
+
+.travel-detail__body p {
+  color: var(--color-text);
+  margin: 0 0 16px;
+  line-height: 1.7;
+}
+
+.travel-detail__body ul,
+.travel-detail__body ol {
+  margin: 0 0 16px;
+  padding-left: 24px;
+  color: var(--color-text);
+}
+
+.travel-detail__body blockquote {
+  margin: 0 0 16px;
+  padding-left: 16px;
+  border-left: 3px solid var(--color-border);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+  .travel-detail {
+    padding: 48px 20px;
+  }
+}

--- a/src/pages/TravelDetail.tsx
+++ b/src/pages/TravelDetail.tsx
@@ -1,0 +1,63 @@
+import { useRef } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { renderMarkdown } from '../lib/markdown';
+import { getTripBySlug } from '../lib/travel';
+import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
+import './TravelDetail.css';
+
+export function TravelDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const trip = slug ? getTripBySlug(slug) : undefined;
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useMarkdownEmbeds(bodyRef, trip?.content);
+
+  if (!trip) {
+    return (
+      <div className="travel-detail">
+        <Link to="/travel" className="travel-detail__back">
+          ← Back to Travel
+        </Link>
+        <p>Trip not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="travel-detail">
+      <Link to="/travel" className="travel-detail__back">
+        ← Back to Travel
+      </Link>
+
+      {trip.cover && (
+        <div className="travel-detail__cover" style={{ backgroundImage: `url(${trip.cover})` }} />
+      )}
+
+      <h1 className="travel-detail__title">{trip.title}</h1>
+      <div className="travel-detail__meta">
+        {trip.location && <span className="travel-detail__location">{trip.location}</span>}
+        <span className="travel-detail__dates mono">
+          {trip.startDate}
+          {trip.endDate ? ` – ${trip.endDate}` : ''}
+        </span>
+        {trip.tags.length > 0 && (
+          <div className="travel-detail__tags">
+            {trip.tags.map((tag) => (
+              <span className="travel-detail__tag mono" key={tag}>
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {trip.content && (
+        <div
+          ref={bodyRef}
+          className="travel-detail__body"
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(trip.content) }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New **Travel** feature (`/travel`, `/travel/:slug`), same content shape as Challenges: markdown + frontmatter under `src/content/travel/<slug>/meta.md`, loaded via `src/lib/travel.ts`. Supports a `hidden: true` flag to unlist a trip from `/travel` while keeping its direct URL reachable.
- New reusable **markdown content embeds** (`src/hooks/useMarkdownEmbeds.ts` + global CSS in `index.css`), usable in any markdown body across Blog, Challenges, and Travel:
  - `.md-gallery` — masonry grid (override column count with `data-columns`), click a photo to grow it in place to a centered preview via a FLIP animation from the thumbnail's actual position, dimming the rest of the gallery; closes on an outside click or `Escape`.
  - `.md-carousel` — auto-advancing slideshow that only plays while scrolled into view, plus prev/next buttons and swipe/drag for manual navigation.
  - `.md-full-bleed` — full viewport-width image, pure CSS, uncropped.
  - Both `.md-gallery` and `.md-carousel` intentionally break out wider than the narrow text column instead of matching body-text width.
- Seeded one example trip ("Kyoto in Autumn") demoing all three embed types.
- `README.md` updated with Challenges/Travel sections and the embeds usage.

Closes #52

## Test plan
- [x] `tsc --noEmit`, `eslint src`, `markdownlint-cli2`, and `npm run build` all pass clean
- [x] Visit `/travel` and `/travel/kyoto-autumn`: click a gallery photo (grows + dims siblings, closes on outside click/Escape), swipe or use the carousel's prev/next buttons, confirm the full-bleed image spans edge-to-edge uncropped
- [x] Confirm gallery/carousel are visibly wider than the surrounding body text, collapsing to full column width on mobile
- [x] Add `hidden: true` to a trip's frontmatter and confirm it disappears from `/travel` but its direct URL still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)