### PR TITLE
Fix mobile nav overflow and add dark mode transitions

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -119,9 +119,45 @@
   color: #fff;
 }
 
-.site-header__theme-icon {
+.site-header__theme-icon-track {
+  position: relative;
+  display: block;
   width: 16px;
   height: 16px;
+}
+
+.site-header__theme-icon {
+  position: absolute;
+  inset: 0;
+  width: 16px;
+  height: 16px;
+  transition: transform 0.5s cubic-bezier(0.65, 0, 0.35, 1), opacity 0.5s ease;
+}
+
+.site-header__theme-icon--visible {
+  transform: translate(0, 0) rotate(0deg);
+  opacity: 1;
+}
+
+.site-header__theme-icon--sun.site-header__theme-icon--hidden {
+  transform: translate(-65%, 65%) rotate(-100deg);
+  opacity: 0;
+}
+
+.site-header__theme-icon--moon.site-header__theme-icon--hidden {
+  transform: translate(65%, 65%) rotate(100deg);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header__theme-icon {
+    transition: opacity 0.2s ease;
+  }
+
+  .site-header__theme-icon--sun.site-header__theme-icon--hidden,
+  .site-header__theme-icon--moon.site-header__theme-icon--hidden {
+    transform: none;
+  }
 }
 
 .site-header__menu-toggle {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,12 +16,7 @@ export function Header({ activeSection }: { activeSection: string }) {
   const isChallenges = location.pathname.startsWith('/challenges');
   const isTravel = location.pathname.startsWith('/travel');
 
-  const navItems = [
-    { id: 'about', label: t.nav.about },
-    { id: 'experience', label: t.nav.experience },
-    { id: 'skills', label: t.nav.skills },
-    { id: 'open-source', label: t.nav.openSource },
-  ];
+  const navItems = [{ id: 'about', label: t.nav.about }];
 
   const langOptions: { value: typeof locale; label: string }[] = [
     { value: 'en', label: 'EN' },
@@ -117,7 +112,18 @@ export function Header({ activeSection }: { activeSection: string }) {
           aria-label={theme === 'dark' ? t.nav.switchToLight : t.nav.switchToDark}
           onClick={toggleTheme}
         >
-          {theme === 'dark' ? <SunIcon className="site-header__theme-icon" /> : <MoonIcon className="site-header__theme-icon" />}
+          <span className="site-header__theme-icon-track">
+            <SunIcon
+              className={`site-header__theme-icon site-header__theme-icon--sun${
+                theme === 'dark' ? ' site-header__theme-icon--hidden' : ' site-header__theme-icon--visible'
+              }`}
+            />
+            <MoonIcon
+              className={`site-header__theme-icon site-header__theme-icon--moon${
+                theme === 'dark' ? ' site-header__theme-icon--visible' : ' site-header__theme-icon--hidden'
+              }`}
+            />
+          </span>
         </button>
       </nav>
     </header>

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,13 @@
 
 * {
   box-sizing: border-box;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none;
+  }
 }
 
 html,


### PR DESCRIPTION
## Summary
- Header's scroll-section links trimmed to just **About** (Experience/Skills/Open Source removed) — on mobile, the full set of links plus the language switcher and theme toggle didn't fit in one row, pushing the dark mode toggle off-screen.
- Dark mode now fades in/out (background/text/border color transition, 0.3s) instead of switching instantly.
- Theme toggle icon now does a "sunset/moonrise" swap: sun exits toward the lower-left rotating + fading, moon enters from the lower-right doing the reverse (and vice versa switching back to light). Both respect `prefers-reduced-motion`.

## Test plan
- [x] `tsc --noEmit`, `eslint src`, `markdownlint-cli2`, and `npm run build` all pass clean
- [ ] On a narrow/mobile viewport, confirm the language switcher and dark mode toggle are fully visible in the header
- [ ] Toggle dark mode and confirm the page fades smoothly and the sun/moon icon does the diagonal swap in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)