### PR TITLE
Set document.title per route

### DIFF
--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export function formatDocumentTitle(pageTitle: string | undefined, siteName: string): string {
+  if (!pageTitle) return siteName;
+  return `${pageTitle} — ${siteName}`;
+}
+
+export function useDocumentTitle(pageTitle: string | undefined, siteName: string) {
+  useEffect(() => {
+    document.title = formatDocumentTitle(pageTitle, siteName);
+  }, [pageTitle, siteName]);
+}

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getAllPosts } from '../lib/posts';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useTranslation } from '../hooks/useTranslation';
 import './BlogList.css';
 
@@ -8,6 +9,7 @@ const PER_PAGE = 5;
 
 export function BlogList() {
   const { t, locale } = useTranslation();
+  useDocumentTitle(t.nav.blog, t.common.name);
   const posts = getAllPosts(locale);
   const [page, setPage] = useState(1);
 

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { renderMarkdown } from '../lib/markdown';
 import { getPostBySlug } from '../lib/posts';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import { useTranslation } from '../hooks/useTranslation';
 import './BlogPost.css';
@@ -11,6 +12,8 @@ export function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
   const post = slug ? getPostBySlug(slug, locale) : undefined;
   const bodyRef = useRef<HTMLDivElement>(null);
+
+  useDocumentTitle(post?.title ?? (slug ? t.blog.notFound : t.nav.blog), t.common.name);
 
   useMarkdownEmbeds(bodyRef, post?.content);
 

--- a/src/pages/ChallengeDetail.tsx
+++ b/src/pages/ChallengeDetail.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from 'react-router-dom';
 import { getChallengeBySlug } from '../lib/challenges';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useTranslation } from '../hooks/useTranslation';
 import './ChallengeDetail.css';
 
@@ -7,6 +8,11 @@ export function ChallengeDetail() {
   const { slug } = useParams<{ slug: string }>();
   const { t, locale } = useTranslation();
   const challenge = slug ? getChallengeBySlug(slug, locale) : undefined;
+
+  useDocumentTitle(
+    challenge?.title ?? (slug ? t.challenges.notFound : t.nav.challenges),
+    t.common.name,
+  );
 
   if (!challenge) {
     return (

--- a/src/pages/ChallengeEntry.tsx
+++ b/src/pages/ChallengeEntry.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { renderMarkdown } from '../lib/markdown';
 import { getChallengeBySlug } from '../lib/challenges';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import { useTranslation } from '../hooks/useTranslation';
 import './ChallengeEntry.css';
@@ -13,6 +14,10 @@ export function ChallengeEntry() {
   const entry = challenge?.entries.find((e) => e.date === date);
   const bodyRef = useRef<HTMLDivElement>(null);
 
+  useDocumentTitle(
+    entry?.title ?? (date ? t.challenges.entryNotFound : challenge?.title ?? t.nav.challenges),
+    t.common.name,
+  );
   useMarkdownEmbeds(bodyRef, entry?.content);
 
   if (!challenge || !entry) {

--- a/src/pages/Challenges.tsx
+++ b/src/pages/Challenges.tsx
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
 import { getAllChallenges } from '../lib/challenges';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useTranslation } from '../hooks/useTranslation';
 import './Challenges.css';
 
 export function Challenges() {
   const { t, locale } = useTranslation();
+  useDocumentTitle(t.nav.challenges, t.common.name);
   const challenges = getAllChallenges(locale);
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Hero } from '../components/Hero';
 import { ScrollDots } from '../components/ScrollDots';
 import { useActiveSection } from '../hooks/useActiveSection';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useTranslation } from '../hooks/useTranslation';
 import { About } from './About';
 import { Experience } from './Experience';
 import { Skills } from './Skills';
@@ -11,8 +13,11 @@ import { OpenSource } from './OpenSource';
 const SECTION_IDS = ['hero', 'about', 'experience', 'skills', 'open-source'];
 
 export function Home() {
+  const { t } = useTranslation();
   const activeSection = useActiveSection(SECTION_IDS);
   const location = useLocation();
+
+  useDocumentTitle(undefined, t.common.name);
   const navigate = useNavigate();
   const hasScrolled = useRef(false);
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,12 @@
 import { Link } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useTranslation } from '../hooks/useTranslation';
 import './NotFound.css';
 
 export function NotFound() {
+  const { t } = useTranslation();
+  useDocumentTitle('404', t.common.name);
+
   return (
     <div className="not-found">
       <h1>404</h1>

--- a/src/pages/NotableContributions.tsx
+++ b/src/pages/NotableContributions.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useTranslation } from '../hooks/useTranslation';
 import { highlights } from '../data/highlights';
 import { PRCard } from '../components/PRCard';
 import './NotableContributions.css';
@@ -25,9 +27,14 @@ for (const pr of allPrs) {
   group.prs.push(pr);
 }
 
+const PAGE_TITLE = 'Notable Contributions';
+
 export function NotableContributions() {
+  const { t } = useTranslation();
   const location = useLocation();
   const isInitialMount = useRef(true);
+
+  useDocumentTitle(PAGE_TITLE, t.common.name);
 
   useEffect(() => {
     if (location.hash) {

--- a/src/pages/Travel.tsx
+++ b/src/pages/Travel.tsx
@@ -1,8 +1,12 @@
 import { Link } from 'react-router-dom';
 import { getAllTrips } from '../lib/travel';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useTranslation } from '../hooks/useTranslation';
 import './Travel.css';
 
 export function Travel() {
+  const { t } = useTranslation();
+  useDocumentTitle(t.nav.travel, t.common.name);
   const trips = getAllTrips();
 
   return (

--- a/src/pages/TravelDetail.tsx
+++ b/src/pages/TravelDetail.tsx
@@ -2,14 +2,18 @@ import { useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { renderMarkdown } from '../lib/markdown';
 import { getTripBySlug } from '../lib/travel';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
+import { useTranslation } from '../hooks/useTranslation';
 import './TravelDetail.css';
 
 export function TravelDetail() {
   const { slug } = useParams<{ slug: string }>();
   const trip = slug ? getTripBySlug(slug) : undefined;
   const bodyRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
 
+  useDocumentTitle(trip?.title ?? (slug ? 'Trip not found' : t.nav.travel), t.common.name);
   useMarkdownEmbeds(bodyRef, trip?.content);
 
   if (!trip) {

--- a/src/pages/WikiHome.tsx
+++ b/src/pages/WikiHome.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { getWikiHandbookMeta, getWikiSections } from '../lib/wiki';
 import { useWikiDrawer } from '../hooks/wikiDrawerContext';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useTranslation } from '../hooks/useTranslation';
 import './WikiHome.css';
 
@@ -9,6 +10,8 @@ export function WikiHome() {
   const { closeDrawer } = useWikiDrawer();
   const meta = getWikiHandbookMeta(locale);
   const sections = getWikiSections(locale);
+
+  useDocumentTitle(meta.title || t.wiki.heading, t.common.name);
 
   return (
     <div className="wiki-home">

--- a/src/pages/WikiPage.tsx
+++ b/src/pages/WikiPage.tsx
@@ -4,6 +4,7 @@ import { renderWikiMarkdown } from '../lib/markdown';
 import { getAdjacentWikiPages, getWikiPageBySlug } from '../lib/wiki';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import { useWikiDrawer } from '../hooks/wikiDrawerContext';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { useTranslation } from '../hooks/useTranslation';
 import './WikiPage.css';
 
@@ -17,6 +18,8 @@ export function WikiPage() {
   const { slug } = useParams<{ slug: string }>();
   const page = slug ? getWikiPageBySlug(slug, locale) : undefined;
   const adjacent = slug ? getAdjacentWikiPages(slug, locale) : { prev: null, next: null };
+
+  useDocumentTitle(page?.title ?? (slug ? t.wiki.notFound : t.wiki.heading), t.common.name);
   const bodyRef = useRef<HTMLDivElement>(null);
 
   const rendered = useMemo(


### PR DESCRIPTION
## Summary
- Add `useDocumentTitle` hook to set the browser tab title on route change
- Apply per-route titles across all pages (Home, Blog, Wiki, Challenges, Travel, Notable Contributions, 404)
- Use i18n site name (`t.common.name`) so titles update when switching locale

Closes #30

## Test plan
- [ ] Run `npm run dev` and navigate to each route — verify the tab title updates
- [ ] Home shows only site name (e.g. `Kuan-Hao Lai`)
- [ ] List pages show `{Section} — {Site Name}` (e.g. `Blog — Kuan-Hao Lai`)
- [ ] Detail pages show `{Content Title} — {Site Name}`
- [ ] Switch locale and confirm site name portion changes (e.g. `賴冠豪`)
- [ ] Visit a non-existent slug and confirm the not-found title appears


Made with [Cursor](https://cursor.com)