### PR TITLE
Add route-based i18n (/zh-TW prefix, no locale flash)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm run test
+
       - name: Lint markdown
         run: npm run lint:md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,23 +10,27 @@ npm run dev       # astro dev server
 npm run build     # astro check && astro build, outputs to dist/
 npm run preview   # serve the production build locally
 npm run lint      # eslint .
+npm run test      # vitest run
+npm run test:watch # vitest (watch mode)
 ```
 
-There is no test suite. There is no `lint --fix` script; fix lint errors manually.
+There is no test suite beyond Vitest unit tests in `tests/**/*.test.ts`. Run `npm run test` before pushing i18n routing changes.
 
 ## Architecture
 
 Personal portfolio site: **Astro static site** with **React islands** (`@astrojs/react`), deployed to GitHub Pages (`guancioul.github.io`, root domain). Path-based routing (`/blog/hello-world`) — each route gets build-time static HTML with Open Graph meta tags. Legacy `#/` URLs redirect client-side via a script in `BaseLayout.astro`.
 
-**Routing:** Astro file-based routes in `src/pages/*.astro`. React page UI lives in `src/views/` and is mounted via island wrappers in `src/islands/AppIslands.tsx`, each wrapped in `PageFrame` (`LocaleProvider` + `Header` + `Footer`).
+**Routing:** Astro file-based routes in `src/pages/*.astro` (English) and `src/pages/zh-TW/*.astro` (Traditional Chinese). Shared page logic lives in `src/route-templates/*.astro`. React page UI lives in `src/views/` and is mounted via island wrappers in `src/islands/AppIslands.tsx`, each wrapped in `PageFrame` (`LocaleProvider` + `Header` + `Footer`). Islands receive a `locale` prop from Astro (`'en' | 'zh-TW'`).
 
-**SEO / OG:** `src/layouts/BaseLayout.astro` sets `<title>`, `og:*`, and `twitter:*` from Astro frontmatter props. Per-route metadata comes from `src/lib/content-meta.ts` (English base content at build time). Runtime locale switching does not affect OG tags (crawlers do not run JS).
+**i18n:** Route-based locales (`astro.config.mjs` → `i18n.routing.prefixDefaultLocale: false`). English at default paths (`/wiki/foo`); Chinese under `/zh-TW/` (`/zh-TW/wiki/foo`). Locale comes from the URL, not `localStorage`. Language switcher navigates to the paired URL via `switchLocalePath`. Internal links use `useLocalizedPath()` / `localizedPath()`. Missing `*.zh-TW.md` content silently falls back to English body at build time. View Transitions via `ClientRouter` in `BaseLayout.astro`.
 
-**Home page (`src/views/Home.tsx`)** is a single scrolling page: `Hero` + `About` + `Experience` + `Skills` + `OpenSource` + fixed `ScrollDots`. `useActiveSection` drives scroll-spy highlighting in both `HomeIsland` (for `ScrollDots`) and `Header`. Cross-route "About" scroll uses `/?scrollTo=about` query param (read once on mount, then cleared with `history.replaceState`).
+**SEO / OG:** `src/layouts/BaseLayout.astro` sets `<html lang>`, `<title>`, `og:*`, and `twitter:*` per locale at build time. Metadata from `src/lib/content-meta.ts` (pass `locale`).
 
-`Header` uses plain `<a href>` links (no React Router). "About" smooth-scrolls on `/`, otherwise navigates to `/?scrollTo=about`.
+**Home page (`src/views/Home.tsx`)** is a single scrolling page: `Hero` + `About` + `Experience` + `Skills` + `OpenSource` + fixed `ScrollDots`. `useActiveSection` drives scroll-spy highlighting in both `HomeIsland` (for `ScrollDots`) and `Header`. Cross-route "About" scroll uses `/?scrollTo=about` (or `/zh-TW/?scrollTo=about`); cleared with `history.replaceState` to the locale home path.
 
-**Blog (`src/views/BlogList.tsx`, `BlogPost.tsx`)**: posts in `src/content/posts/*.md` with frontmatter (`title`, `date`, `summary`). `src/lib/posts.ts` loads via `import.meta.glob` + hand-rolled `parseFrontmatter` in `src/lib/markdown.ts`. Sibling `*.zh-TW.md` files provide runtime locale overrides. `BlogPost` renders via `marked` + `dangerouslySetInnerHTML` + `useMarkdownEmbeds`.
+`Header` uses locale-aware `<a href>` links. "About" smooth-scrolls on home, otherwise navigates to `{home}?scrollTo=about`.
+
+**Blog (`src/views/BlogList.tsx`, `BlogPost.tsx`)**: posts in `src/content/posts/*.md` with frontmatter (`title`, `date`, `summary`). `src/lib/posts.ts` loads via `import.meta.glob` + hand-rolled `parseFrontmatter` in `src/lib/markdown.ts`. Sibling `*.zh-TW.md` files provide locale overrides (fallback to English when missing).
 
 **Wiki (`src/views/WikiShell.tsx`, `WikiHome.tsx`, `WikiPage.tsx`)**: handbook pages in `src/content/wiki/<section>/*.md`. `src/lib/wiki.ts` builds section tree, locale fallbacks, prev/next nav. `WikiShell` provides desktop sidebar + mobile drawer.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,13 @@ export default defineConfig({
   site: 'https://guancioul.github.io',
   base: '/',
   integrations: [react()],
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'zh-TW'],
+    routing: {
+      prefixDefaultLocale: false,
+    },
+  },
   build: {
     format: 'directory',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,33 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^26.1.0",
         "markdownlint-cli2": "^0.22.1",
         "typescript": "~6.0.2",
-        "typescript-eslint": "^8.59.2"
+        "typescript-eslint": "^8.59.2",
+        "vitest": "^3.2.6"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.9",
@@ -885,6 +908,121 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -2521,6 +2659,370 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@shikijs/core": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.0.tgz",
@@ -2685,6 +3187,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2694,6 +3207,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3048,6 +3568,94 @@
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
@@ -3176,6 +3784,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3272,6 +3890,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -3626,6 +4254,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -3654,6 +4292,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3696,6 +4351,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3975,11 +4640,39 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3998,6 +4691,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -4010,6 +4710,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -4517,6 +5227,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5010,6 +5730,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -5031,6 +5764,47 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5225,6 +5999,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -5263,6 +6044,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -5673,6 +6494,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6526,6 +7354,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -6726,6 +7561,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/piccolore": {
@@ -7103,6 +7955,58 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7126,6 +8030,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/satteri": {
       "version": "0.9.3",
@@ -7162,6 +8073,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7279,6 +8203,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7329,6 +8260,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
@@ -7376,6 +8321,26 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/svgo": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
@@ -7410,6 +8375,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
@@ -7430,6 +8402,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
@@ -7466,6 +8445,56 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7477,6 +8506,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -8068,6 +9123,111 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -8083,6 +9243,198 @@
       },
       "peerDependenciesMeta": {
         "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -8383,6 +9735,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8391,6 +9756,54 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -8416,6 +9829,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -8483,6 +9913,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "astro check && astro build",
     "lint": "eslint .",
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "astro preview"
   },
   "dependencies": {
@@ -29,8 +31,10 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "jsdom": "^26.1.0",
     "markdownlint-cli2": "^0.22.1",
     "typescript": "~6.0.2",
-    "typescript-eslint": "^8.59.2"
+    "typescript-eslint": "^8.59.2",
+    "vitest": "^3.2.6"
   }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTheme } from '../hooks/useTheme';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import { MoonIcon, SunIcon } from './ThemeIcons';
 import './Header.css';
 
@@ -14,6 +15,7 @@ export function Header({
   const [menuOpen, setMenuOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const { locale, setLocale, t } = useTranslation();
+  const lp = useLocalizedPath();
   const isHome = currentPath === '/';
   const isBlog = currentPath.startsWith('/blog');
   const isWiki = currentPath.startsWith('/wiki');
@@ -32,7 +34,7 @@ export function Header({
     if (isHome) {
       document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     } else {
-      window.location.assign(`/?scrollTo=${id}`);
+      window.location.assign(`${lp('/')}?scrollTo=${id}`);
     }
   }
 
@@ -41,7 +43,7 @@ export function Header({
     if (isHome) {
       document.getElementById('hero')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     } else {
-      window.location.assign('/');
+      window.location.assign(lp('/'));
     }
   }
 
@@ -73,28 +75,28 @@ export function Header({
           </button>
         ))}
         <a
-          href="/blog"
+          href={lp('/blog')}
           className={`site-header__link${isBlog ? ' site-header__link--active' : ''}`}
           onClick={() => setMenuOpen(false)}
         >
           {t.nav.blog}
         </a>
         <a
-          href="/wiki"
+          href={lp('/wiki')}
           className={`site-header__link${isWiki ? ' site-header__link--active' : ''}`}
           onClick={() => setMenuOpen(false)}
         >
           {t.nav.wiki}
         </a>
         <a
-          href="/challenges"
+          href={lp('/challenges')}
           className={`site-header__link${isChallenges ? ' site-header__link--active' : ''}`}
           onClick={() => setMenuOpen(false)}
         >
           {t.nav.challenges}
         </a>
         <a
-          href="/travel"
+          href={lp('/travel')}
           className={`site-header__link${isTravel ? ' site-header__link--active' : ''}`}
           onClick={() => setMenuOpen(false)}
         >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,10 +1,12 @@
 import personalPhoto from '../assets/avatar.png';
 import { email, githubUrl, role } from '../data/profile';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './Hero.css';
 
 export function Hero() {
   const { t } = useTranslation();
+  const lp = useLocalizedPath();
 
   return (
     <section id="hero" className="hero">
@@ -19,7 +21,7 @@ export function Hero() {
             <a className="hero__button hero__button--primary" href={githubUrl} target="_blank" rel="noopener">
               {t.hero.githubButton}
             </a>
-            <a className="hero__button" href="/blog">
+            <a className="hero__button" href={lp('/blog')}>
               {t.hero.blogButton}
             </a>
           </div>

--- a/src/components/PageFrame.tsx
+++ b/src/components/PageFrame.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Locale } from '../i18n';
 import { LocaleProvider } from '../hooks/useLocale';
 import { Header } from './Header';
 import { Footer } from './Footer';
@@ -6,13 +7,15 @@ import '../App.css';
 
 interface PageFrameProps {
   children: ReactNode;
+  locale: Locale;
+  /** Locale-neutral path, e.g. `/wiki/foo` (no `/zh-TW` prefix). */
   currentPath: string;
   activeSection?: string;
 }
 
-export function PageFrame({ children, currentPath, activeSection = '' }: PageFrameProps) {
+export function PageFrame({ children, locale, currentPath, activeSection = '' }: PageFrameProps) {
   return (
-    <LocaleProvider>
+    <LocaleProvider locale={locale}>
       <div className="app">
         <Header activeSection={activeSection} currentPath={currentPath} />
         <main className="app-main">{children}</main>

--- a/src/hooks/useLocale.tsx
+++ b/src/hooks/useLocale.tsx
@@ -1,35 +1,30 @@
-import { useEffect, useState } from 'react';
-import type { ReactNode } from 'react';
-import { defaultLocale, locales, type Locale } from '../i18n';
+import { useEffect, type ReactNode } from 'react';
+import { navigate } from 'astro:transitions/client';
+import { locales, type Locale } from '../i18n';
+import { buildLocaleSwitchUrl, saveLocaleSwitchScroll } from '../lib/locale-scroll';
 import { LocaleContext } from './localeContext';
 
-const STORAGE_KEY = 'locale';
-
-function isLocale(value: string | null): value is Locale {
-  return value === 'en' || value === 'zh-TW';
-}
-
-function getInitialLocale(): Locale {
-  if (typeof window === 'undefined') return defaultLocale;
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (isLocale(stored)) return stored;
-  } catch {
-    // localStorage unavailable (private mode, quota) — fall through to language detection
-  }
-  return navigator.language.startsWith('zh') ? 'zh-TW' : defaultLocale;
-}
-
-export function LocaleProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocale] = useState<Locale>(getInitialLocale);
+export function LocaleProvider({
+  locale,
+  children,
+}: {
+  locale: Locale;
+  children: ReactNode;
+}) {
+  const setLocale = (next: Locale) => {
+    if (next === locale) return;
+    saveLocaleSwitchScroll();
+    const url = buildLocaleSwitchUrl(
+      window.location.pathname,
+      window.location.search,
+      window.location.hash,
+      next,
+    );
+    void navigate(url);
+  };
 
   useEffect(() => {
-    document.documentElement.setAttribute('lang', locale);
-    try {
-      localStorage.setItem(STORAGE_KEY, locale);
-    } catch {
-      // localStorage unavailable — skip persisting
-    }
+    document.documentElement.setAttribute('lang', locale === 'zh-TW' ? 'zh-TW' : 'en');
   }, [locale]);
 
   return <LocaleContext value={{ locale, setLocale, t: locales[locale] }}>{children}</LocaleContext>;

--- a/src/hooks/useLocalizedPath.ts
+++ b/src/hooks/useLocalizedPath.ts
@@ -1,0 +1,8 @@
+import { useCallback } from 'react';
+import { localizedPath } from '../lib/locale-path';
+import { useTranslation } from './useTranslation';
+
+export function useLocalizedPath() {
+  const { locale } = useTranslation();
+  return useCallback((path: string) => localizedPath(locale, path), [locale]);
+}

--- a/src/islands/AppIslands.tsx
+++ b/src/islands/AppIslands.tsx
@@ -1,3 +1,4 @@
+import type { Locale } from '../i18n';
 import { useActiveSection } from '../hooks/useActiveSection';
 import { PageFrame } from '../components/PageFrame';
 import { Home, HOME_SECTION_IDS } from '../views/Home';
@@ -15,90 +16,98 @@ import { WikiHome } from '../views/WikiHome';
 import { WikiPage } from '../views/WikiPage';
 import '../views/NotFound.css';
 
-export function HomeIsland() {
+export function HomeIsland({ locale }: { locale: Locale }) {
   const activeSection = useActiveSection(HOME_SECTION_IDS);
   return (
-    <PageFrame currentPath="/" activeSection={activeSection}>
+    <PageFrame locale={locale} currentPath="/" activeSection={activeSection}>
       <Home />
     </PageFrame>
   );
 }
 
-export function BlogListIsland() {
+export function BlogListIsland({ locale }: { locale: Locale }) {
   return (
-    <PageFrame currentPath="/blog">
+    <PageFrame locale={locale} currentPath="/blog">
       <BlogList />
     </PageFrame>
   );
 }
 
-export function BlogPostIsland({ slug }: { slug: string }) {
+export function BlogPostIsland({ slug, locale }: { slug: string; locale: Locale }) {
   return (
-    <PageFrame currentPath={`/blog/${slug}`}>
+    <PageFrame locale={locale} currentPath={`/blog/${slug}`}>
       <BlogPost slug={slug} />
     </PageFrame>
   );
 }
 
-export function ChallengesIsland() {
+export function ChallengesIsland({ locale }: { locale: Locale }) {
   return (
-    <PageFrame currentPath="/challenges">
+    <PageFrame locale={locale} currentPath="/challenges">
       <Challenges />
     </PageFrame>
   );
 }
 
-export function ChallengeDetailIsland({ slug }: { slug: string }) {
+export function ChallengeDetailIsland({ slug, locale }: { slug: string; locale: Locale }) {
   return (
-    <PageFrame currentPath={`/challenges/${slug}`}>
+    <PageFrame locale={locale} currentPath={`/challenges/${slug}`}>
       <ChallengeDetail slug={slug} />
     </PageFrame>
   );
 }
 
-export function ChallengeEntryIsland({ slug, date }: { slug: string; date: string }) {
+export function ChallengeEntryIsland({
+  slug,
+  date,
+  locale,
+}: {
+  slug: string;
+  date: string;
+  locale: Locale;
+}) {
   return (
-    <PageFrame currentPath={`/challenges/${slug}/${date}`}>
+    <PageFrame locale={locale} currentPath={`/challenges/${slug}/${date}`}>
       <ChallengeEntry slug={slug} date={date} />
     </PageFrame>
   );
 }
 
-export function TravelIsland() {
+export function TravelIsland({ locale }: { locale: Locale }) {
   return (
-    <PageFrame currentPath="/travel">
+    <PageFrame locale={locale} currentPath="/travel">
       <Travel />
     </PageFrame>
   );
 }
 
-export function TravelDetailIsland({ slug }: { slug: string }) {
+export function TravelDetailIsland({ slug, locale }: { slug: string; locale: Locale }) {
   return (
-    <PageFrame currentPath={`/travel/${slug}`}>
+    <PageFrame locale={locale} currentPath={`/travel/${slug}`}>
       <TravelDetail slug={slug} />
     </PageFrame>
   );
 }
 
-export function NotableContributionsIsland() {
+export function NotableContributionsIsland({ locale }: { locale: Locale }) {
   return (
-    <PageFrame currentPath="/notable-contributions">
+    <PageFrame locale={locale} currentPath="/notable-contributions">
       <NotableContributions />
     </PageFrame>
   );
 }
 
-export function NotFoundIsland() {
+export function NotFoundIsland({ locale }: { locale: Locale }) {
   return (
-    <PageFrame currentPath="/404">
+    <PageFrame locale={locale} currentPath="/404">
       <NotFoundView />
     </PageFrame>
   );
 }
 
-export function WikiHomeIsland() {
+export function WikiHomeIsland({ locale }: { locale: Locale }) {
   return (
-    <PageFrame currentPath="/wiki">
+    <PageFrame locale={locale} currentPath="/wiki">
       <WikiShell>
         <WikiHome />
       </WikiShell>
@@ -106,9 +115,9 @@ export function WikiHomeIsland() {
   );
 }
 
-export function WikiPageIsland({ slug }: { slug: string }) {
+export function WikiPageIsland({ slug, locale }: { slug: string; locale: Locale }) {
   return (
-    <PageFrame currentPath={`/wiki/${slug}`}>
+    <PageFrame locale={locale} currentPath={`/wiki/${slug}`}>
       <WikiShell activeSlug={slug}>
         <WikiPage slug={slug} />
       </WikiShell>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,9 +1,12 @@
 ---
 import '../index.css';
 import '../App.css';
+import { ClientRouter } from 'astro:transitions';
 import { formatPageTitle, absoluteUrl, DEFAULT_OG_IMAGE } from '../lib/site';
+import type { Locale } from '../i18n';
 
 interface Props {
+  locale?: Locale;
   title?: string;
   description?: string;
   url?: string;
@@ -12,6 +15,7 @@ interface Props {
 }
 
 const {
+  locale = 'en',
   title,
   description = '',
   url = Astro.url.pathname,
@@ -22,14 +26,16 @@ const {
 const pageTitle = formatPageTitle(title);
 const canonicalUrl = absoluteUrl(url);
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : absoluteUrl(ogImage);
+const htmlLang = locale === 'zh-TW' ? 'zh-TW' : 'en';
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={htmlLang} transition:animate="fade">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <ClientRouter />
     <title>{pageTitle}</title>
     {description && <meta name="description" content={description} />}
     <meta property="og:title" content={pageTitle} />
@@ -43,20 +49,63 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : absoluteUrl(ogImage);
     <meta name="twitter:image" content={ogImageUrl} />
     <script is:inline>
       (function () {
+        function applyTheme(doc) {
+          try {
+            var stored = localStorage.getItem('theme');
+            var theme =
+              stored === 'light' || stored === 'dark'
+                ? stored
+                : window.matchMedia('(prefers-color-scheme: dark)').matches
+                  ? 'dark'
+                  : 'light';
+            doc.documentElement.setAttribute('data-theme', theme);
+          } catch (e) {}
+        }
+
         if (location.hash.startsWith('#/')) {
           location.replace(location.hash.slice(1));
           return;
         }
-        try {
-          var stored = localStorage.getItem('theme');
-          var theme =
-            stored === 'light' || stored === 'dark'
-              ? stored
-              : window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light';
-          document.documentElement.setAttribute('data-theme', theme);
-        } catch (e) {}
+
+        applyTheme(document);
+
+        document.addEventListener('astro:before-swap', function (event) {
+          applyTheme(event.newDocument);
+        });
+
+        function restoreLocaleSwitchScroll() {
+          try {
+            var scroll = sessionStorage.getItem('locale-switch-scroll');
+            if (scroll === null) return false;
+            var y = parseInt(scroll, 10);
+            if (!Number.isFinite(y)) return false;
+            window.scrollTo(0, y);
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+
+        function finishLocaleSwitchScrollRestore() {
+          try {
+            sessionStorage.removeItem('locale-switch-scroll');
+          } catch (e) {}
+        }
+
+        function scheduleLocaleSwitchScrollRestore() {
+          if (!restoreLocaleSwitchScroll()) return;
+          requestAnimationFrame(function () {
+            restoreLocaleSwitchScroll();
+            requestAnimationFrame(function () {
+              restoreLocaleSwitchScroll();
+              finishLocaleSwitchScrollRestore();
+            });
+          });
+        }
+
+        document.addEventListener('astro:page-load', scheduleLocaleSwitchScrollRestore);
+        document.addEventListener('astro:after-swap', restoreLocaleSwitchScroll);
+        scheduleLocaleSwitchScrollRestore();
       })();
     </script>
   </head>
@@ -64,3 +113,22 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : absoluteUrl(ogImage);
     <slot />
   </body>
 </html>
+
+<style is:global>
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes fade-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/lib/content-meta.ts
+++ b/src/lib/content-meta.ts
@@ -1,29 +1,53 @@
+import { locales, type Locale } from '../i18n';
 import { getAllPosts, getPostBySlug } from './posts';
 import { getAllChallenges, getChallengeBySlug } from './challenges';
 import { getAllTrips, getTripBySlug } from './travel';
+import { localizedPath, notFoundPath } from './locale-path';
 import { getWikiHandbookMeta, getWikiPageBySlug, getWikiSections } from './wiki';
 
 export function getBlogStaticPaths() {
   return getAllPosts('en').map((post) => ({ params: { slug: post.slug } }));
 }
 
-export function getBlogMeta(slug: string) {
-  const post = getPostBySlug(slug, 'en');
+export function getBlogListMeta(locale: Locale = 'en') {
+  return {
+    title: locales[locale].nav.blog,
+    description: locale === 'zh-TW' ? 'Kuan-Hao Lai 的部落格文章。' : 'Blog posts by Kuan-Hao Lai.',
+    url: localizedPath(locale, '/blog'),
+  };
+}
+
+export function getBlogMeta(slug: string, locale: Locale = 'en') {
+  const post = getPostBySlug(slug, locale);
   if (!post) return null;
-  return { title: post.title, description: post.summary, url: `/blog/${slug}`, ogType: 'article' as const };
+  return {
+    title: post.title,
+    description: post.summary,
+    url: localizedPath(locale, `/blog/${slug}`),
+    ogType: 'article' as const,
+  };
 }
 
 export function getChallengeStaticPaths() {
   return getAllChallenges('en').map((c) => ({ params: { slug: c.slug } }));
 }
 
-export function getChallengeMeta(slug: string) {
-  const challenge = getChallengeBySlug(slug, 'en');
+export function getChallengesListMeta(locale: Locale = 'en') {
+  return {
+    title: locales[locale].nav.challenges,
+    description:
+      locale === 'zh-TW' ? '個人挑戰與每日紀錄。' : 'Personal challenges and daily logs.',
+    url: localizedPath(locale, '/challenges'),
+  };
+}
+
+export function getChallengeMeta(slug: string, locale: Locale = 'en') {
+  const challenge = getChallengeBySlug(slug, locale);
   if (!challenge) return null;
   return {
     title: challenge.title,
     description: challenge.summary,
-    url: `/challenges/${slug}`,
+    url: localizedPath(locale, `/challenges/${slug}`),
     ogImage: challenge.image || undefined,
   };
 }
@@ -34,14 +58,14 @@ export function getChallengeEntryStaticPaths() {
   );
 }
 
-export function getChallengeEntryMeta(slug: string, date: string) {
-  const challenge = getChallengeBySlug(slug, 'en');
+export function getChallengeEntryMeta(slug: string, date: string, locale: Locale = 'en') {
+  const challenge = getChallengeBySlug(slug, locale);
   const entry = challenge?.entries.find((e) => e.date === date);
   if (!entry) return null;
   return {
     title: entry.title,
     description: entry.preview,
-    url: `/challenges/${slug}/${date}`,
+    url: localizedPath(locale, `/challenges/${slug}/${date}`),
     ogType: 'article' as const,
     ogImage: challenge?.image || undefined,
   };
@@ -51,13 +75,21 @@ export function getTravelStaticPaths() {
   return getAllTrips().map((t) => ({ params: { slug: t.slug } }));
 }
 
-export function getTravelMeta(slug: string) {
+export function getTravelListMeta(locale: Locale = 'en') {
+  return {
+    title: locales[locale].nav.travel,
+    description: locale === 'zh-TW' ? '旅行紀錄與行程筆記。' : 'Travel logs and trip notes.',
+    url: localizedPath(locale, '/travel'),
+  };
+}
+
+export function getTravelMeta(slug: string, locale: Locale = 'en') {
   const trip = getTripBySlug(slug);
   if (!trip) return null;
   return {
     title: trip.title,
     description: trip.summary,
-    url: `/travel/${slug}`,
+    url: localizedPath(locale, `/travel/${slug}`),
     ogImage: trip.cover || undefined,
   };
 }
@@ -68,13 +100,30 @@ export function getWikiPageStaticPaths() {
   );
 }
 
-export function getWikiPageMeta(slug: string) {
-  const page = getWikiPageBySlug(slug, 'en');
+export function getWikiPageMeta(slug: string, locale: Locale = 'en') {
+  const page = getWikiPageBySlug(slug, locale);
   if (!page) return null;
-  return { title: page.title, description: page.summary, url: `/wiki/${slug}` };
+  return { title: page.title, description: page.summary, url: localizedPath(locale, `/wiki/${slug}`) };
 }
 
-export function getWikiHomeMeta() {
-  const meta = getWikiHandbookMeta('en');
-  return { title: meta.title || 'Wiki', description: meta.intro, url: '/wiki' };
+export function getWikiHomeMeta(locale: Locale = 'en') {
+  const meta = getWikiHandbookMeta(locale);
+  return { title: meta.title || 'Wiki', description: meta.intro, url: localizedPath(locale, '/wiki') };
 }
+
+export function getNotableContributionsMeta(locale: Locale = 'en') {
+  return {
+    title: locale === 'zh-TW' ? '重要貢獻' : 'Notable Contributions',
+    description:
+      locale === 'zh-TW'
+        ? '在 CNCF 等開源專案的精選 pull request。'
+        : 'Selected open source pull requests across CNCF projects.',
+    url: localizedPath(locale, '/notable-contributions'),
+  };
+}
+
+export function getNotFoundMeta(locale: Locale = 'en') {
+  return { title: '404', url: notFoundPath(locale) };
+}
+
+export { notFoundPath };

--- a/src/lib/locale-path.ts
+++ b/src/lib/locale-path.ts
@@ -1,0 +1,28 @@
+import { defaultLocale, type Locale } from '../i18n';
+
+const ZH_TW_PREFIX = '/zh-TW';
+
+/** Locale-neutral path (always starts with `/`, never includes `/zh-TW`). */
+export function localizedPath(locale: Locale, path: string): string {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  if (locale === defaultLocale) return normalized;
+  if (normalized === '/') return `${ZH_TW_PREFIX}/`;
+  return `${ZH_TW_PREFIX}${normalized}`;
+}
+
+export function parseLocaleFromPath(pathname: string): { locale: Locale; path: string } {
+  if (pathname === ZH_TW_PREFIX || pathname.startsWith(`${ZH_TW_PREFIX}/`)) {
+    const path = pathname === ZH_TW_PREFIX ? '/' : pathname.slice(ZH_TW_PREFIX.length) || '/';
+    return { locale: 'zh-TW', path };
+  }
+  return { locale: defaultLocale, path: pathname || '/' };
+}
+
+export function switchLocalePath(pathname: string, targetLocale: Locale): string {
+  const { path } = parseLocaleFromPath(pathname);
+  return localizedPath(targetLocale, path);
+}
+
+export function notFoundPath(locale: Locale): string {
+  return localizedPath(locale, '/404');
+}

--- a/src/lib/locale-scroll.ts
+++ b/src/lib/locale-scroll.ts
@@ -1,0 +1,21 @@
+import type { Locale } from '../i18n';
+import { switchLocalePath } from './locale-path';
+
+export const LOCALE_SWITCH_SCROLL_KEY = 'locale-switch-scroll';
+
+export function buildLocaleSwitchUrl(
+  pathname: string,
+  search: string,
+  hash: string,
+  targetLocale: Locale,
+): string {
+  return `${switchLocalePath(pathname, targetLocale)}${search}${hash}`;
+}
+
+export function saveLocaleSwitchScroll(): void {
+  try {
+    sessionStorage.setItem(LOCALE_SWITCH_SCROLL_KEY, String(window.scrollY));
+  } catch {
+    // sessionStorage unavailable
+  }
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,8 +1,5 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { NotFoundIsland } from '../islands/AppIslands';
+import NotFoundRoute from '../route-templates/NotFoundRoute.astro';
 ---
 
-<BaseLayout title="404" url="/404">
-  <NotFoundIsland client:load />
-</BaseLayout>
+<NotFoundRoute locale="en" />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,25 +1,12 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { BlogPostIsland } from '../../islands/AppIslands';
-import { getBlogMeta, getBlogStaticPaths } from '../../lib/content-meta';
+import BlogPostRoute from '../../route-templates/BlogPostRoute.astro';
+import { getBlogStaticPaths } from '../../lib/content-meta';
 
 export function getStaticPaths() {
   return getBlogStaticPaths();
 }
 
 const { slug } = Astro.params;
-const meta = getBlogMeta(slug!);
-
-if (!meta) {
-  return Astro.redirect('/404');
-}
 ---
 
-<BaseLayout
-  title={meta.title}
-  description={meta.description}
-  url={meta.url}
-  ogType={meta.ogType}
->
-  <BlogPostIsland client:load slug={slug!} />
-</BaseLayout>
+<BlogPostRoute locale="en" slug={slug!} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,8 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { BlogListIsland } from '../../islands/AppIslands';
+import BlogListRoute from '../../route-templates/BlogListRoute.astro';
 ---
 
-<BaseLayout title="Blog" description="Blog posts by Kuan-Hao Lai." url="/blog">
-  <BlogListIsland client:load />
-</BaseLayout>
+<BlogListRoute locale="en" />

--- a/src/pages/challenges/[slug].astro
+++ b/src/pages/challenges/[slug].astro
@@ -1,25 +1,12 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { ChallengeDetailIsland } from '../../islands/AppIslands';
-import { getChallengeMeta, getChallengeStaticPaths } from '../../lib/content-meta';
+import ChallengeDetailRoute from '../../route-templates/ChallengeDetailRoute.astro';
+import { getChallengeStaticPaths } from '../../lib/content-meta';
 
 export function getStaticPaths() {
   return getChallengeStaticPaths();
 }
 
 const { slug } = Astro.params;
-const meta = getChallengeMeta(slug!);
-
-if (!meta) {
-  return Astro.redirect('/404');
-}
 ---
 
-<BaseLayout
-  title={meta.title}
-  description={meta.description}
-  url={meta.url}
-  ogImage={meta.ogImage}
->
-  <ChallengeDetailIsland client:load slug={slug!} />
-</BaseLayout>
+<ChallengeDetailRoute locale="en" slug={slug!} />

--- a/src/pages/challenges/[slug]/[date].astro
+++ b/src/pages/challenges/[slug]/[date].astro
@@ -1,26 +1,12 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { ChallengeEntryIsland } from '../../../islands/AppIslands';
-import { getChallengeEntryMeta, getChallengeEntryStaticPaths } from '../../../lib/content-meta';
+import ChallengeEntryRoute from '../../../route-templates/ChallengeEntryRoute.astro';
+import { getChallengeEntryStaticPaths } from '../../../lib/content-meta';
 
 export function getStaticPaths() {
   return getChallengeEntryStaticPaths();
 }
 
 const { slug, date } = Astro.params;
-const meta = getChallengeEntryMeta(slug!, date!);
-
-if (!meta) {
-  return Astro.redirect('/404');
-}
 ---
 
-<BaseLayout
-  title={meta.title}
-  description={meta.description}
-  url={meta.url}
-  ogType={meta.ogType}
-  ogImage={meta.ogImage}
->
-  <ChallengeEntryIsland client:load slug={slug!} date={date!} />
-</BaseLayout>
+<ChallengeEntryRoute locale="en" slug={slug!} date={date!} />

--- a/src/pages/challenges/index.astro
+++ b/src/pages/challenges/index.astro
@@ -1,8 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { ChallengesIsland } from '../../islands/AppIslands';
+import ChallengesListRoute from '../../route-templates/ChallengesListRoute.astro';
 ---
 
-<BaseLayout title="Challenges" description="Personal challenges and daily logs." url="/challenges">
-  <ChallengesIsland client:load />
-</BaseLayout>
+<ChallengesListRoute locale="en" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,5 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { HomeIsland } from '../islands/AppIslands';
+import HomeRoute from '../route-templates/HomeRoute.astro';
 ---
 
-<BaseLayout>
-  <HomeIsland client:load />
-</BaseLayout>
+<HomeRoute locale="en" />

--- a/src/pages/notable-contributions.astro
+++ b/src/pages/notable-contributions.astro
@@ -1,12 +1,5 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import { NotableContributionsIsland } from '../islands/AppIslands';
+import NotableContributionsRoute from '../route-templates/NotableContributionsRoute.astro';
 ---
 
-<BaseLayout
-  title="Notable Contributions"
-  description="Selected open source pull requests across CNCF projects."
-  url="/notable-contributions"
->
-  <NotableContributionsIsland client:load />
-</BaseLayout>
+<NotableContributionsRoute locale="en" />

--- a/src/pages/travel/[slug].astro
+++ b/src/pages/travel/[slug].astro
@@ -1,25 +1,12 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { TravelDetailIsland } from '../../islands/AppIslands';
-import { getTravelMeta, getTravelStaticPaths } from '../../lib/content-meta';
+import TravelDetailRoute from '../../route-templates/TravelDetailRoute.astro';
+import { getTravelStaticPaths } from '../../lib/content-meta';
 
 export function getStaticPaths() {
   return getTravelStaticPaths();
 }
 
 const { slug } = Astro.params;
-const meta = getTravelMeta(slug!);
-
-if (!meta) {
-  return Astro.redirect('/404');
-}
 ---
 
-<BaseLayout
-  title={meta.title}
-  description={meta.description}
-  url={meta.url}
-  ogImage={meta.ogImage}
->
-  <TravelDetailIsland client:load slug={slug!} />
-</BaseLayout>
+<TravelDetailRoute locale="en" slug={slug!} />

--- a/src/pages/travel/index.astro
+++ b/src/pages/travel/index.astro
@@ -1,8 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { TravelIsland } from '../../islands/AppIslands';
+import TravelListRoute from '../../route-templates/TravelListRoute.astro';
 ---
 
-<BaseLayout title="Travel" description="Travel logs and trip notes." url="/travel">
-  <TravelIsland client:load />
-</BaseLayout>
+<TravelListRoute locale="en" />

--- a/src/pages/wiki/[slug].astro
+++ b/src/pages/wiki/[slug].astro
@@ -1,20 +1,12 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { WikiPageIsland } from '../../islands/AppIslands';
-import { getWikiPageMeta, getWikiPageStaticPaths } from '../../lib/content-meta';
+import WikiPageRoute from '../../route-templates/WikiPageRoute.astro';
+import { getWikiPageStaticPaths } from '../../lib/content-meta';
 
 export function getStaticPaths() {
   return getWikiPageStaticPaths();
 }
 
 const { slug } = Astro.params;
-const meta = getWikiPageMeta(slug!);
-
-if (!meta) {
-  return Astro.redirect('/404');
-}
 ---
 
-<BaseLayout title={meta.title} description={meta.description} url={meta.url}>
-  <WikiPageIsland client:load slug={slug!} />
-</BaseLayout>
+<WikiPageRoute locale="en" slug={slug!} />

--- a/src/pages/wiki/index.astro
+++ b/src/pages/wiki/index.astro
@@ -1,11 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { getWikiHomeMeta } from '../../lib/content-meta';
-import { WikiHomeIsland } from '../../islands/AppIslands';
-
-const meta = getWikiHomeMeta();
+import WikiHomeRoute from '../../route-templates/WikiHomeRoute.astro';
 ---
 
-<BaseLayout title={meta.title} description={meta.description} url={meta.url}>
-  <WikiHomeIsland client:load />
-</BaseLayout>
+<WikiHomeRoute locale="en" />

--- a/src/pages/zh-TW/404.astro
+++ b/src/pages/zh-TW/404.astro
@@ -1,0 +1,5 @@
+---
+import NotFoundRoute from '../../route-templates/NotFoundRoute.astro';
+---
+
+<NotFoundRoute locale="zh-TW" />

--- a/src/pages/zh-TW/blog/[slug].astro
+++ b/src/pages/zh-TW/blog/[slug].astro
@@ -1,0 +1,12 @@
+---
+import BlogPostRoute from '../../../route-templates/BlogPostRoute.astro';
+import { getBlogStaticPaths } from '../../../lib/content-meta';
+
+export function getStaticPaths() {
+  return getBlogStaticPaths();
+}
+
+const { slug } = Astro.params;
+---
+
+<BlogPostRoute locale="zh-TW" slug={slug!} />

--- a/src/pages/zh-TW/blog/index.astro
+++ b/src/pages/zh-TW/blog/index.astro
@@ -1,0 +1,5 @@
+---
+import BlogListRoute from '../../../route-templates/BlogListRoute.astro';
+---
+
+<BlogListRoute locale="zh-TW" />

--- a/src/pages/zh-TW/challenges/[slug].astro
+++ b/src/pages/zh-TW/challenges/[slug].astro
@@ -1,0 +1,12 @@
+---
+import ChallengeDetailRoute from '../../../route-templates/ChallengeDetailRoute.astro';
+import { getChallengeStaticPaths } from '../../../lib/content-meta';
+
+export function getStaticPaths() {
+  return getChallengeStaticPaths();
+}
+
+const { slug } = Astro.params;
+---
+
+<ChallengeDetailRoute locale="zh-TW" slug={slug!} />

--- a/src/pages/zh-TW/challenges/[slug]/[date].astro
+++ b/src/pages/zh-TW/challenges/[slug]/[date].astro
@@ -1,0 +1,12 @@
+---
+import ChallengeEntryRoute from '../../../../route-templates/ChallengeEntryRoute.astro';
+import { getChallengeEntryStaticPaths } from '../../../../lib/content-meta';
+
+export function getStaticPaths() {
+  return getChallengeEntryStaticPaths();
+}
+
+const { slug, date } = Astro.params;
+---
+
+<ChallengeEntryRoute locale="zh-TW" slug={slug!} date={date!} />

--- a/src/pages/zh-TW/challenges/index.astro
+++ b/src/pages/zh-TW/challenges/index.astro
@@ -1,0 +1,5 @@
+---
+import ChallengesListRoute from '../../../route-templates/ChallengesListRoute.astro';
+---
+
+<ChallengesListRoute locale="zh-TW" />

--- a/src/pages/zh-TW/index.astro
+++ b/src/pages/zh-TW/index.astro
@@ -1,0 +1,5 @@
+---
+import HomeRoute from '../../route-templates/HomeRoute.astro';
+---
+
+<HomeRoute locale="zh-TW" />

--- a/src/pages/zh-TW/notable-contributions.astro
+++ b/src/pages/zh-TW/notable-contributions.astro
@@ -1,0 +1,5 @@
+---
+import NotableContributionsRoute from '../../route-templates/NotableContributionsRoute.astro';
+---
+
+<NotableContributionsRoute locale="zh-TW" />

--- a/src/pages/zh-TW/travel/[slug].astro
+++ b/src/pages/zh-TW/travel/[slug].astro
@@ -1,0 +1,12 @@
+---
+import TravelDetailRoute from '../../../route-templates/TravelDetailRoute.astro';
+import { getTravelStaticPaths } from '../../../lib/content-meta';
+
+export function getStaticPaths() {
+  return getTravelStaticPaths();
+}
+
+const { slug } = Astro.params;
+---
+
+<TravelDetailRoute locale="zh-TW" slug={slug!} />

--- a/src/pages/zh-TW/travel/index.astro
+++ b/src/pages/zh-TW/travel/index.astro
@@ -1,0 +1,5 @@
+---
+import TravelListRoute from '../../../route-templates/TravelListRoute.astro';
+---
+
+<TravelListRoute locale="zh-TW" />

--- a/src/pages/zh-TW/wiki/[slug].astro
+++ b/src/pages/zh-TW/wiki/[slug].astro
@@ -1,0 +1,12 @@
+---
+import WikiPageRoute from '../../../route-templates/WikiPageRoute.astro';
+import { getWikiPageStaticPaths } from '../../../lib/content-meta';
+
+export function getStaticPaths() {
+  return getWikiPageStaticPaths();
+}
+
+const { slug } = Astro.params;
+---
+
+<WikiPageRoute locale="zh-TW" slug={slug!} />

--- a/src/pages/zh-TW/wiki/index.astro
+++ b/src/pages/zh-TW/wiki/index.astro
@@ -1,0 +1,5 @@
+---
+import WikiHomeRoute from '../../../route-templates/WikiHomeRoute.astro';
+---
+
+<WikiHomeRoute locale="zh-TW" />

--- a/src/route-templates/BlogListRoute.astro
+++ b/src/route-templates/BlogListRoute.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { BlogListIsland } from '../islands/AppIslands';
+import { getBlogListMeta } from '../lib/content-meta';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const meta = getBlogListMeta(locale);
+---
+
+<BaseLayout locale={locale} title={meta.title} description={meta.description} url={meta.url}>
+  <BlogListIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/BlogPostRoute.astro
+++ b/src/route-templates/BlogPostRoute.astro
@@ -1,0 +1,29 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { BlogPostIsland } from '../islands/AppIslands';
+import { getBlogMeta } from '../lib/content-meta';
+import { notFoundPath } from '../lib/locale-path';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+  slug: string;
+}
+
+const { locale, slug } = Astro.props;
+const meta = getBlogMeta(slug, locale);
+
+if (!meta) {
+  return Astro.redirect(notFoundPath(locale));
+}
+---
+
+<BaseLayout
+  locale={locale}
+  title={meta.title}
+  description={meta.description}
+  url={meta.url}
+  ogType={meta.ogType}
+>
+  <BlogPostIsland client:load slug={slug} locale={locale} />
+</BaseLayout>

--- a/src/route-templates/ChallengeDetailRoute.astro
+++ b/src/route-templates/ChallengeDetailRoute.astro
@@ -1,0 +1,29 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { ChallengeDetailIsland } from '../islands/AppIslands';
+import { getChallengeMeta } from '../lib/content-meta';
+import { notFoundPath } from '../lib/locale-path';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+  slug: string;
+}
+
+const { locale, slug } = Astro.props;
+const meta = getChallengeMeta(slug, locale);
+
+if (!meta) {
+  return Astro.redirect(notFoundPath(locale));
+}
+---
+
+<BaseLayout
+  locale={locale}
+  title={meta.title}
+  description={meta.description}
+  url={meta.url}
+  ogImage={meta.ogImage}
+>
+  <ChallengeDetailIsland client:load slug={slug} locale={locale} />
+</BaseLayout>

--- a/src/route-templates/ChallengeEntryRoute.astro
+++ b/src/route-templates/ChallengeEntryRoute.astro
@@ -1,0 +1,31 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { ChallengeEntryIsland } from '../islands/AppIslands';
+import { getChallengeEntryMeta } from '../lib/content-meta';
+import { notFoundPath } from '../lib/locale-path';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+  slug: string;
+  date: string;
+}
+
+const { locale, slug, date } = Astro.props;
+const meta = getChallengeEntryMeta(slug, date, locale);
+
+if (!meta) {
+  return Astro.redirect(notFoundPath(locale));
+}
+---
+
+<BaseLayout
+  locale={locale}
+  title={meta.title}
+  description={meta.description}
+  url={meta.url}
+  ogType={meta.ogType}
+  ogImage={meta.ogImage}
+>
+  <ChallengeEntryIsland client:load slug={slug} date={date} locale={locale} />
+</BaseLayout>

--- a/src/route-templates/ChallengesListRoute.astro
+++ b/src/route-templates/ChallengesListRoute.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { ChallengesIsland } from '../islands/AppIslands';
+import { getChallengesListMeta } from '../lib/content-meta';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const meta = getChallengesListMeta(locale);
+---
+
+<BaseLayout locale={locale} title={meta.title} description={meta.description} url={meta.url}>
+  <ChallengesIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/HomeRoute.astro
+++ b/src/route-templates/HomeRoute.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { HomeIsland } from '../islands/AppIslands';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+---
+
+<BaseLayout locale={locale}>
+  <HomeIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/NotFoundRoute.astro
+++ b/src/route-templates/NotFoundRoute.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { NotFoundIsland } from '../islands/AppIslands';
+import { getNotFoundMeta } from '../lib/content-meta';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const meta = getNotFoundMeta(locale);
+---
+
+<BaseLayout locale={locale} title={meta.title} url={meta.url}>
+  <NotFoundIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/NotableContributionsRoute.astro
+++ b/src/route-templates/NotableContributionsRoute.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { NotableContributionsIsland } from '../islands/AppIslands';
+import { getNotableContributionsMeta } from '../lib/content-meta';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const meta = getNotableContributionsMeta(locale);
+---
+
+<BaseLayout locale={locale} title={meta.title} description={meta.description} url={meta.url}>
+  <NotableContributionsIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/TravelDetailRoute.astro
+++ b/src/route-templates/TravelDetailRoute.astro
@@ -1,0 +1,29 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { TravelDetailIsland } from '../islands/AppIslands';
+import { getTravelMeta } from '../lib/content-meta';
+import { notFoundPath } from '../lib/locale-path';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+  slug: string;
+}
+
+const { locale, slug } = Astro.props;
+const meta = getTravelMeta(slug, locale);
+
+if (!meta) {
+  return Astro.redirect(notFoundPath(locale));
+}
+---
+
+<BaseLayout
+  locale={locale}
+  title={meta.title}
+  description={meta.description}
+  url={meta.url}
+  ogImage={meta.ogImage}
+>
+  <TravelDetailIsland client:load slug={slug} locale={locale} />
+</BaseLayout>

--- a/src/route-templates/TravelListRoute.astro
+++ b/src/route-templates/TravelListRoute.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { TravelIsland } from '../islands/AppIslands';
+import { getTravelListMeta } from '../lib/content-meta';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const meta = getTravelListMeta(locale);
+---
+
+<BaseLayout locale={locale} title={meta.title} description={meta.description} url={meta.url}>
+  <TravelIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/WikiHomeRoute.astro
+++ b/src/route-templates/WikiHomeRoute.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { WikiHomeIsland } from '../islands/AppIslands';
+import { getWikiHomeMeta } from '../lib/content-meta';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const meta = getWikiHomeMeta(locale);
+---
+
+<BaseLayout locale={locale} title={meta.title} description={meta.description} url={meta.url}>
+  <WikiHomeIsland client:load locale={locale} />
+</BaseLayout>

--- a/src/route-templates/WikiPageRoute.astro
+++ b/src/route-templates/WikiPageRoute.astro
@@ -1,0 +1,23 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { WikiPageIsland } from '../islands/AppIslands';
+import { getWikiPageMeta } from '../lib/content-meta';
+import { notFoundPath } from '../lib/locale-path';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale: Locale;
+  slug: string;
+}
+
+const { locale, slug } = Astro.props;
+const meta = getWikiPageMeta(slug, locale);
+
+if (!meta) {
+  return Astro.redirect(notFoundPath(locale));
+}
+---
+
+<BaseLayout locale={locale} title={meta.title} description={meta.description} url={meta.url}>
+  <WikiPageIsland client:load slug={slug} locale={locale} />
+</BaseLayout>

--- a/src/views/BlogList.tsx
+++ b/src/views/BlogList.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { getAllPosts } from '../lib/posts';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './BlogList.css';
 
 const PER_PAGE = 5;
 
 export function BlogList() {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const posts = getAllPosts(locale);
   const [page, setPage] = useState(1);
 
@@ -25,7 +27,7 @@ export function BlogList() {
           {pageItems.map((post) => (
             <article className="blog-list__item" key={post.slug}>
               <div className="blog-list__item-header">
-                <a href={`/blog/${post.slug}`} className="blog-list__item-title">
+                <a href={lp(`/blog/${post.slug}`)} className="blog-list__item-title">
                   {post.title}
                 </a>
                 <span className="blog-list__item-date mono">{post.date}</span>

--- a/src/views/BlogPost.tsx
+++ b/src/views/BlogPost.tsx
@@ -3,10 +3,12 @@ import { renderMarkdown } from '../lib/markdown';
 import { getPostBySlug } from '../lib/posts';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './BlogPost.css';
 
 export function BlogPost({ slug }: { slug: string }) {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const post = getPostBySlug(slug, locale);
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -15,7 +17,7 @@ export function BlogPost({ slug }: { slug: string }) {
   if (!post) {
     return (
       <div className="blog-post">
-        <a href="/blog" className="blog-post__back">
+        <a href={lp('/blog')} className="blog-post__back">
           {t.common.backTo(t.nav.blog)}
         </a>
         <p>{t.blog.notFound}</p>
@@ -25,7 +27,7 @@ export function BlogPost({ slug }: { slug: string }) {
 
   return (
     <div className="blog-post">
-      <a href="/blog" className="blog-post__back">
+      <a href={lp('/blog')} className="blog-post__back">
         {t.common.backTo(t.nav.blog)}
       </a>
       <h1 className="blog-post__title">{post.title}</h1>

--- a/src/views/ChallengeDetail.tsx
+++ b/src/views/ChallengeDetail.tsx
@@ -1,15 +1,17 @@
 import { getChallengeBySlug } from '../lib/challenges';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './ChallengeDetail.css';
 
 export function ChallengeDetail({ slug }: { slug: string }) {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const challenge = getChallengeBySlug(slug, locale);
 
   if (!challenge) {
     return (
       <div className="challenge-detail">
-        <a href="/challenges" className="challenge-detail__back">
+        <a href={lp('/challenges')} className="challenge-detail__back">
           {t.common.backTo(t.nav.challenges)}
         </a>
         <p>{t.challenges.notFound}</p>
@@ -24,7 +26,7 @@ export function ChallengeDetail({ slug }: { slug: string }) {
 
   return (
     <div className="challenge-detail">
-      <a href="/challenges" className="challenge-detail__back">
+      <a href={lp('/challenges')} className="challenge-detail__back">
         {t.common.backTo(t.nav.challenges)}
       </a>
 
@@ -74,7 +76,7 @@ export function ChallengeDetail({ slug }: { slug: string }) {
         <div className="challenge-detail__entries">
           {challenge.entries.map((entry) => (
             <a
-              href={`/challenges/${challenge.slug}/${entry.date}`}
+              href={lp(`/challenges/${challenge.slug}/${entry.date}`)}
               className="challenge-entry"
               key={entry.date}
             >

--- a/src/views/ChallengeEntry.tsx
+++ b/src/views/ChallengeEntry.tsx
@@ -3,10 +3,12 @@ import { renderMarkdown } from '../lib/markdown';
 import { getChallengeBySlug } from '../lib/challenges';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './ChallengeEntry.css';
 
 export function ChallengeEntry({ slug, date }: { slug: string; date: string }) {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const challenge = getChallengeBySlug(slug, locale);
   const entry = challenge?.entries.find((e) => e.date === date);
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -16,7 +18,7 @@ export function ChallengeEntry({ slug, date }: { slug: string; date: string }) {
   if (!challenge || !entry) {
     return (
       <div className="challenge-entry-page">
-        <a href={slug ? `/challenges/${slug}` : '/challenges'} className="challenge-entry-page__back">
+        <a href={slug ? lp(`/challenges/${slug}`) : lp('/challenges')} className="challenge-entry-page__back">
           {t.common.backTo(challenge?.title ?? t.challenges.singular)}
         </a>
         <p>{t.challenges.entryNotFound}</p>
@@ -30,7 +32,7 @@ export function ChallengeEntry({ slug, date }: { slug: string; date: string }) {
 
   return (
     <div className="challenge-entry-page">
-      <a href={`/challenges/${challenge.slug}`} className="challenge-entry-page__back">
+      <a href={lp(`/challenges/${challenge.slug}`)} className="challenge-entry-page__back">
         {t.common.backTo(challenge.title)}
       </a>
 
@@ -44,14 +46,14 @@ export function ChallengeEntry({ slug, date }: { slug: string; date: string }) {
 
       <div className="challenge-entry-page__nav">
         {prev ? (
-          <a href={`/challenges/${challenge.slug}/${prev.date}`} className="challenge-entry-page__nav-link">
+          <a href={lp(`/challenges/${challenge.slug}/${prev.date}`)} className="challenge-entry-page__nav-link">
             ← {prev.date}
           </a>
         ) : (
           <span />
         )}
         {next && (
-          <a href={`/challenges/${challenge.slug}/${next.date}`} className="challenge-entry-page__nav-link">
+          <a href={lp(`/challenges/${challenge.slug}/${next.date}`)} className="challenge-entry-page__nav-link">
             {next.date} →
           </a>
         )}

--- a/src/views/Challenges.tsx
+++ b/src/views/Challenges.tsx
@@ -1,9 +1,11 @@
 import { getAllChallenges } from '../lib/challenges';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './Challenges.css';
 
 export function Challenges() {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const challenges = getAllChallenges(locale);
 
   return (
@@ -21,7 +23,7 @@ export function Challenges() {
               : null;
 
             return (
-              <a href={`/challenges/${challenge.slug}`} className="challenge-card" key={challenge.slug}>
+              <a href={lp(`/challenges/${challenge.slug}`)} className="challenge-card" key={challenge.slug}>
                 {challenge.image && (
                   <div className="challenge-card__image" style={{ backgroundImage: `url(${challenge.image})` }} />
                 )}

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import { Hero } from '../components/Hero';
 import { ScrollDots } from '../components/ScrollDots';
 import { useActiveSection } from '../hooks/useActiveSection';
+import { useTranslation } from '../hooks/useTranslation';
+import { localizedPath } from '../lib/locale-path';
 import { About } from './About';
 import { Experience } from './Experience';
 import { Skills } from './Skills';
@@ -12,15 +14,16 @@ const SECTION_IDS = ['hero', 'about', 'experience', 'skills', 'open-source'];
 export function Home() {
   const activeSection = useActiveSection(SECTION_IDS);
   const hasScrolled = useRef(false);
+  const { locale } = useTranslation();
 
   useEffect(() => {
     const scrollTo = new URLSearchParams(window.location.search).get('scrollTo');
     if (scrollTo && !hasScrolled.current) {
       hasScrolled.current = true;
       document.getElementById(scrollTo)?.scrollIntoView({ behavior: 'smooth' });
-      window.history.replaceState({}, '', '/');
+      window.history.replaceState({}, '', localizedPath(locale, '/'));
     }
-  }, []);
+  }, [locale]);
 
   return (
     <>

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -1,10 +1,16 @@
+import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
+
 export function NotFoundView() {
+  const { t } = useTranslation();
+  const lp = useLocalizedPath();
+
   return (
     <div className="not-found">
       <h1>404</h1>
       <p>Page not found.</p>
-      <a href="/" className="not-found__link">
-        ← Back home
+      <a href={lp('/')} className="not-found__link">
+        ← {t.common.backTo('Home')}
       </a>
     </div>
   );

--- a/src/views/OpenSource.tsx
+++ b/src/views/OpenSource.tsx
@@ -2,10 +2,13 @@ import { DevStat } from '../components/DevStat';
 import { githubUsername } from '../data/profile';
 import { GithubContributions } from '../components/GithubContributions';
 import { SectionHeading } from '../components/SectionHeading';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './Skills.css';
 import './OpenSource.css';
 
 export function OpenSource() {
+  const lp = useLocalizedPath();
+
   return (
     <section id="open-source" className="page">
       <div className="page__heading">
@@ -14,7 +17,7 @@ export function OpenSource() {
 
       <div className="page__body">
         <p>My open source pull request contributions across various projects.</p>
-        <a href="/notable-contributions" className="open-source__notable-link">
+        <a href={lp('/notable-contributions')} className="open-source__notable-link">
           Notable Contributions →
         </a>
         <GithubContributions username={githubUsername} />

--- a/src/views/Travel.tsx
+++ b/src/views/Travel.tsx
@@ -1,9 +1,11 @@
 import { getAllTrips } from '../lib/travel';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './Travel.css';
 
 export function Travel() {
   const { t } = useTranslation();
+  const lp = useLocalizedPath();
   const trips = getAllTrips();
 
   return (
@@ -15,7 +17,7 @@ export function Travel() {
       ) : (
         <div className="travel__grid">
           {trips.map((trip) => (
-            <a href={`/travel/${trip.slug}`} className="trip-card" key={trip.slug}>
+            <a href={lp(`/travel/${trip.slug}`)} className="trip-card" key={trip.slug}>
               {trip.cover && (
                 <div className="trip-card__image" style={{ backgroundImage: `url(${trip.cover})` }} />
               )}

--- a/src/views/TravelDetail.tsx
+++ b/src/views/TravelDetail.tsx
@@ -2,9 +2,13 @@ import { useRef } from 'react';
 import { renderMarkdown } from '../lib/markdown';
 import { getTripBySlug } from '../lib/travel';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
+import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './TravelDetail.css';
 
 export function TravelDetail({ slug }: { slug: string }) {
+  const { t } = useTranslation();
+  const lp = useLocalizedPath();
   const trip = getTripBySlug(slug);
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -13,8 +17,8 @@ export function TravelDetail({ slug }: { slug: string }) {
   if (!trip) {
     return (
       <div className="travel-detail">
-        <a href="/travel" className="travel-detail__back">
-          ← Back to Travel
+        <a href={lp('/travel')} className="travel-detail__back">
+          {t.common.backTo(t.nav.travel)}
         </a>
         <p>Trip not found.</p>
       </div>
@@ -23,8 +27,8 @@ export function TravelDetail({ slug }: { slug: string }) {
 
   return (
     <div className="travel-detail">
-      <a href="/travel" className="travel-detail__back">
-        ← Back to Travel
+      <a href={lp('/travel')} className="travel-detail__back">
+        {t.common.backTo(t.nav.travel)}
       </a>
 
       {trip.cover && (

--- a/src/views/WikiHome.tsx
+++ b/src/views/WikiHome.tsx
@@ -1,10 +1,12 @@
 import { getWikiHandbookMeta, getWikiSections } from '../lib/wiki';
 import { useWikiDrawer } from '../hooks/wikiDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './WikiHome.css';
 
 export function WikiHome() {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const { closeDrawer } = useWikiDrawer();
   const meta = getWikiHandbookMeta(locale);
   const sections = getWikiSections(locale);
@@ -24,7 +26,7 @@ export function WikiHome() {
               <ul className="wiki-home__pages">
                 {section.pages.map((page) => (
                   <li className="wiki-home__page" key={page.slug}>
-                    <a href={`/wiki/${page.slug}`} className="wiki-home__page-link" onClick={closeDrawer}>
+                    <a href={lp(`/wiki/${page.slug}`)} className="wiki-home__page-link" onClick={closeDrawer}>
                       {page.title}
                     </a>
                     {page.summary && <p className="wiki-home__page-summary">{page.summary}</p>}

--- a/src/views/WikiPage.tsx
+++ b/src/views/WikiPage.tsx
@@ -4,6 +4,7 @@ import { getAdjacentWikiPages, getWikiPageBySlug } from '../lib/wiki';
 import { useMarkdownEmbeds } from '../hooks/useMarkdownEmbeds';
 import { useWikiDrawer } from '../hooks/wikiDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './WikiPage.css';
 
 function scrollToHeading(id: string) {
@@ -12,6 +13,7 @@ function scrollToHeading(id: string) {
 
 export function WikiPage({ slug }: { slug: string }) {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const { closeDrawer } = useWikiDrawer();
   const page = getWikiPageBySlug(slug, locale);
   const adjacent = getAdjacentWikiPages(slug, locale);
@@ -27,7 +29,7 @@ export function WikiPage({ slug }: { slug: string }) {
   if (!page) {
     return (
       <div className="wiki-article">
-        <a href="/wiki" className="wiki-article__back">
+        <a href={lp('/wiki')} className="wiki-article__back">
           {t.common.backTo(t.nav.wiki)}
         </a>
         <p>{t.wiki.notFound}</p>
@@ -54,7 +56,7 @@ export function WikiPage({ slug }: { slug: string }) {
           <nav className="wiki-article__pager" aria-label="Wiki page navigation">
             {adjacent.prev ? (
               <a
-                href={`/wiki/${adjacent.prev.slug}`}
+                href={lp(`/wiki/${adjacent.prev.slug}`)}
                 className="wiki-article__pager-link wiki-article__pager-link--prev"
                 onClick={closeDrawer}
               >
@@ -66,7 +68,7 @@ export function WikiPage({ slug }: { slug: string }) {
             )}
             {adjacent.next ? (
               <a
-                href={`/wiki/${adjacent.next.slug}`}
+                href={lp(`/wiki/${adjacent.next.slug}`)}
                 className="wiki-article__pager-link wiki-article__pager-link--next"
                 onClick={closeDrawer}
               >

--- a/src/views/WikiShell.tsx
+++ b/src/views/WikiShell.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getWikiPageBySlug, getWikiSections } from '../lib/wiki';
 import { WikiDrawerContext } from '../hooks/wikiDrawerContext';
 import { useTranslation } from '../hooks/useTranslation';
+import { useLocalizedPath } from '../hooks/useLocalizedPath';
 import './WikiLayout.css';
 
 function WikiSidebarNav({
@@ -13,12 +14,13 @@ function WikiSidebarNav({
   activeSlug?: string;
 }) {
   const { t, locale } = useTranslation();
+  const lp = useLocalizedPath();
   const sections = getWikiSections(locale);
 
   return (
     <nav className="wiki-sidebar__nav" aria-label="Wiki handbook">
       <a
-        href="/wiki"
+        href={lp('/wiki')}
         className={`wiki-sidebar__home${activeSlug ? '' : ' wiki-sidebar__home--active'}`}
         onClick={onNavigate}
       >
@@ -31,7 +33,7 @@ function WikiSidebarNav({
             {section.pages.map((page) => (
               <li key={page.slug}>
                 <a
-                  href={`/wiki/${page.slug}`}
+                  href={lp(`/wiki/${page.slug}`)}
                   className={`wiki-sidebar__link${activeSlug === page.slug ? ' wiki-sidebar__link--active' : ''}`}
                   aria-current={activeSlug === page.slug ? 'page' : undefined}
                   onClick={onNavigate}

--- a/tests/content-locale.test.ts
+++ b/tests/content-locale.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { getAllChallenges, getChallengeBySlug } from '../src/lib/challenges';
+import { getAllPosts, getPostBySlug } from '../src/lib/posts';
+import { getWikiPageBySlug, getWikiSections } from '../src/lib/wiki';
+import { getTripBySlug } from '../src/lib/travel';
+
+describe('content locale routing parity', () => {
+  it('exposes the same wiki slugs regardless of locale', () => {
+    const enSlugs = getWikiSections('en')
+      .flatMap((s) => s.pages.map((p) => p.slug))
+      .sort();
+    const zhSlugs = getWikiSections('zh-TW')
+      .flatMap((s) => s.pages.map((p) => p.slug))
+      .sort();
+    expect(zhSlugs).toEqual(enSlugs);
+  });
+
+  it('exposes the same challenge slugs and entry dates for EN and zh-TW', () => {
+    const en = getAllChallenges('en');
+    const zh = getAllChallenges('zh-TW');
+    expect(zh.map((c) => c.slug).sort()).toEqual(en.map((c) => c.slug).sort());
+
+    for (const slug of en.map((c) => c.slug)) {
+      const enDates = getChallengeBySlug(slug, 'en')!.entries.map((e) => e.date).sort();
+      const zhDates = getChallengeBySlug(slug, 'zh-TW')!.entries.map((e) => e.date).sort();
+      expect(zhDates).toEqual(enDates);
+    }
+  });
+
+  it('exposes the same blog slugs for EN and zh-TW', () => {
+    const enSlugs = getAllPosts('en').map((p) => p.slug).sort();
+    const zhSlugs = getAllPosts('zh-TW').map((p) => p.slug).sort();
+    expect(zhSlugs).toEqual(enSlugs);
+  });
+});
+
+describe('content locale selection', () => {
+  it('returns zh-TW wiki content when translation exists', () => {
+    const en = getWikiPageBySlug('dopamine-detox', 'en');
+    const zh = getWikiPageBySlug('dopamine-detox', 'zh-TW');
+    expect(en).toBeDefined();
+    expect(zh).toBeDefined();
+    expect(zh!.title).not.toBe(en!.title);
+    expect(zh!.content).not.toBe(en!.content);
+  });
+
+  it('returns zh-TW challenge entry when translation exists', () => {
+    const slug = 'dopamine-detox';
+    const date = '2026-06-28';
+    const enEntry = getChallengeBySlug(slug, 'en')?.entries.find((e) => e.date === date);
+    const zhEntry = getChallengeBySlug(slug, 'zh-TW')?.entries.find((e) => e.date === date);
+    expect(enEntry).toBeDefined();
+    expect(zhEntry).toBeDefined();
+    expect(zhEntry!.content).not.toBe(enEntry!.content);
+  });
+
+  it('returns zh-TW blog post when translation exists', () => {
+    const en = getPostBySlug('hello-world', 'en');
+    const zh = getPostBySlug('hello-world', 'zh-TW');
+    expect(en).toBeDefined();
+    expect(zh).toBeDefined();
+    expect(zh!.content).not.toBe(en!.content);
+  });
+
+  it('serves travel content without a locale dimension (implicit English fallback)', () => {
+    const trip = getTripBySlug('kyoto-autumn');
+    expect(trip).toBeDefined();
+    expect(trip!.title.length).toBeGreaterThan(0);
+  });
+});
+
+describe('localized content-meta URLs', () => {
+  it('builds matching EN and zh-TW wiki URLs', async () => {
+    const { getWikiPageMeta, getChallengesListMeta } = await import('../src/lib/content-meta');
+    const en = getWikiPageMeta('dopamine-detox', 'en');
+    const zh = getWikiPageMeta('dopamine-detox', 'zh-TW');
+    expect(en!.url).toBe('/wiki/dopamine-detox');
+    expect(zh!.url).toBe('/zh-TW/wiki/dopamine-detox');
+
+    const enList = getChallengesListMeta('en');
+    const zhList = getChallengesListMeta('zh-TW');
+    expect(enList.url).toBe('/challenges');
+    expect(zhList.url).toBe('/zh-TW/challenges');
+  });
+});

--- a/tests/locale-path.test.ts
+++ b/tests/locale-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  localizedPath,
+  notFoundPath,
+  parseLocaleFromPath,
+  switchLocalePath,
+} from '../src/lib/locale-path';
+
+describe('localizedPath', () => {
+  it('keeps English paths unprefixed', () => {
+    expect(localizedPath('en', '/')).toBe('/');
+    expect(localizedPath('en', '/wiki/foo')).toBe('/wiki/foo');
+  });
+
+  it('prefixes zh-TW paths', () => {
+    expect(localizedPath('zh-TW', '/')).toBe('/zh-TW/');
+    expect(localizedPath('zh-TW', '/wiki/foo')).toBe('/zh-TW/wiki/foo');
+  });
+
+  it('normalizes paths without a leading slash', () => {
+    expect(localizedPath('en', 'blog')).toBe('/blog');
+    expect(localizedPath('zh-TW', 'challenges/x')).toBe('/zh-TW/challenges/x');
+  });
+});
+
+describe('parseLocaleFromPath', () => {
+  it('parses English routes', () => {
+    expect(parseLocaleFromPath('/wiki/foo')).toEqual({ locale: 'en', path: '/wiki/foo' });
+    expect(parseLocaleFromPath('/')).toEqual({ locale: 'en', path: '/' });
+  });
+
+  it('parses zh-TW routes', () => {
+    expect(parseLocaleFromPath('/zh-TW')).toEqual({ locale: 'zh-TW', path: '/' });
+    expect(parseLocaleFromPath('/zh-TW/wiki/foo')).toEqual({ locale: 'zh-TW', path: '/wiki/foo' });
+  });
+});
+
+describe('switchLocalePath', () => {
+  it('swaps locale while keeping the logical path', () => {
+    expect(switchLocalePath('/wiki/dopamine-detox', 'zh-TW')).toBe('/zh-TW/wiki/dopamine-detox');
+    expect(switchLocalePath('/zh-TW/challenges/project-50', 'en')).toBe('/challenges/project-50');
+  });
+});
+
+describe('notFoundPath', () => {
+  it('localizes 404 routes', () => {
+    expect(notFoundPath('en')).toBe('/404');
+    expect(notFoundPath('zh-TW')).toBe('/zh-TW/404');
+  });
+});
+
+describe('round-trip', () => {
+  it('switching locale twice returns to the original logical path', () => {
+    const logical = '/challenges/dopamine-detox/2026-06-28';
+    const zh = switchLocalePath(logical, 'zh-TW');
+    expect(switchLocalePath(zh, 'en')).toBe(logical);
+  });
+});

--- a/tests/locale-scroll.test.ts
+++ b/tests/locale-scroll.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  LOCALE_SWITCH_SCROLL_KEY,
+  buildLocaleSwitchUrl,
+  saveLocaleSwitchScroll,
+} from '../src/lib/locale-scroll';
+
+describe('buildLocaleSwitchUrl', () => {
+  it('preserves query string and hash when switching locale', () => {
+    expect(
+      buildLocaleSwitchUrl('/wiki/foo', '?scrollTo=about', '#section', 'zh-TW'),
+    ).toBe('/zh-TW/wiki/foo?scrollTo=about#section');
+  });
+
+  it('strips zh-TW prefix when switching back to English', () => {
+    expect(
+      buildLocaleSwitchUrl('/zh-TW/challenges/project-50', '', '#day-6', 'en'),
+    ).toBe('/challenges/project-50#day-6');
+  });
+});
+
+describe('saveLocaleSwitchScroll', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('stores the current scroll position for post-navigation restore', () => {
+    Object.defineProperty(window, 'scrollY', { value: 842, configurable: true });
+    saveLocaleSwitchScroll();
+    expect(sessionStorage.getItem(LOCALE_SWITCH_SCROLL_KEY)).toBe('842');
+  });
+
+  it('does not throw when sessionStorage is unavailable', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => saveLocaleSwitchScroll()).not.toThrow();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Switch from runtime `localStorage` locale to route-based i18n: English at default paths, Traditional Chinese under `/zh-TW/` (`prefixDefaultLocale: false`)
- Build dual static HTML per route (48 pages) so first paint matches URL locale — fixes wiki/challenge navigation flash (#76)
- Language switcher navigates to paired URL via Astro `navigate()`; preserves scroll position and `data-theme` across View Transitions
- Missing `*.zh-TW.md` content silently falls back to English body
- Add Vitest unit tests (`tests/`) for locale paths, scroll URL building, and content/locale parity; run in CI

## Test plan
- [ ] `npm run test` passes
- [ ] `npm run lint && npm run build` pass
- [ ] `/zh-TW/wiki/dopamine-detox` — Chinese on first paint, sidebar links stay in zh-TW
- [ ] Language switch EN ↔ 中 — fade transition, no theme flash, scroll roughly preserved
- [ ] `/wiki/prep-sites` ↔ `/zh-TW/wiki/prep-sites` — works; untranslated pages show EN body under zh-TW chrome


Made with [Cursor](https://cursor.com)