### PR TITLE
Add Cursor rule: ask before git commit or PR

### DIFF
--- a/.cursor/rules/git-operations.mdc
+++ b/.cursor/rules/git-operations.mdc
@@ -1,0 +1,16 @@
+---
+description: Always ask before git commit or opening a pull request
+alwaysApply: true
+---
+
+# Git commit and PR operations
+
+Do **not** run `git commit`, `git push`, or `gh pr create` unless the user has explicitly asked in the current message.
+
+When code is ready:
+
+1. Summarize the changes and tell the user what would be committed.
+2. Ask whether to commit, push, and/or open a PR.
+3. Only proceed after explicit confirmation.
+
+This applies even during hotfixes or when the work seems obviously complete.


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/git-operations.mdc` as an always-on agent rule
- Agents must ask for confirmation before `git commit`, `git push`, or `gh pr create`, unless the user explicitly requests those actions in the current message

## Test plan
- [ ] Merge and verify the rule appears in Cursor project rules
- [ ] Confirm agents pause and ask before unsolicited git operations


Made with [Cursor](https://cursor.com)