### PR TITLE
Extract shared .panel styles out of Skills.css

### DIFF
--- a/src/components/Panel.css
+++ b/src/components/Panel.css
@@ -1,0 +1,26 @@
+.panel {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  margin-bottom: 24px;
+  overflow: visible;
+}
+
+.panel__header {
+  font-weight: 600;
+  font-size: 14px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.panel__row {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.panel__row:last-child {
+  border-bottom: none;
+}

--- a/src/components/SkillTagPill.tsx
+++ b/src/components/SkillTagPill.tsx
@@ -9,7 +9,7 @@ const CREDLY_C_PATH =
 export function CredlyBadge({ inline = false }: { inline?: boolean }) {
   return (
     <svg
-      className={inline ? 'skill-panel__footnote-icon' : 'skill-tag__credly-badge'}
+      className={inline ? 'panel__footnote-icon' : 'skill-tag__credly-badge'}
       width="12"
       height="12"
       viewBox="0 0 20 20"

--- a/src/views/OpenSource.tsx
+++ b/src/views/OpenSource.tsx
@@ -3,7 +3,7 @@ import { githubUsername } from '../data/profile';
 import { GithubContributions } from '../components/GithubContributions';
 import { SectionHeading } from '../components/SectionHeading';
 import { useLocalizedPath } from '../hooks/useLocalizedPath';
-import './Skills.css';
+import '../components/Panel.css';
 import './OpenSource.css';
 
 export function OpenSource() {
@@ -22,9 +22,9 @@ export function OpenSource() {
         </a>
         <GithubContributions username={githubUsername} />
 
-        <div className="skill-panel open-source__cncf-panel">
-          <div className="skill-panel__header">CNCF Stats</div>
-          <div className="skill-panel__row open-source__cncf-row">
+        <div className="panel open-source__cncf-panel">
+          <div className="panel__header">CNCF Stats</div>
+          <div className="panel__row open-source__cncf-row">
             <DevStat username={githubUsername} />
           </div>
         </div>

--- a/src/views/Skills.css
+++ b/src/views/Skills.css
@@ -1,40 +1,13 @@
-.skill-panel {
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background: var(--color-surface);
-  margin-bottom: 24px;
-  overflow: visible;
-}
-
-.skill-panel__header {
-  font-weight: 600;
-  font-size: 14px;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.skill-panel__row {
-  padding: 16px 18px;
-  border-bottom: 1px solid var(--color-border);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.skill-panel__row:last-child {
-  border-bottom: none;
-}
-
-.skill-panel__row-label {
+.panel__row-label {
   font-size: 13px;
   font-weight: 600;
 }
 
-.skill-panel__row--collapsible {
+.panel__row--collapsible {
   padding: 0;
 }
 
-.skill-panel__row-summary {
+.panel__row-summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -46,11 +19,11 @@
   list-style: none;
 }
 
-.skill-panel__row-summary::-webkit-details-marker {
+.panel__row-summary::-webkit-details-marker {
   display: none;
 }
 
-.skill-panel__row-summary::after {
+.panel__row-summary::after {
   content: '';
   flex-shrink: 0;
   width: 7px;
@@ -62,22 +35,22 @@
   transition: transform 0.15s ease;
 }
 
-.skill-panel__row--collapsible[open] .skill-panel__row-summary::after {
+.panel__row--collapsible[open] .panel__row-summary::after {
   transform: rotate(-135deg);
   margin-top: 4px;
 }
 
-.skill-panel__row-summary-meta {
+.panel__row-summary-meta {
   font-size: 12px;
   font-weight: 500;
   color: var(--color-text-muted);
 }
 
-.skill-panel__tags--collapsible {
+.panel__tags--collapsible {
   padding: 0 18px 16px;
 }
 
-.skill-panel__tags {
+.panel__tags {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -122,7 +95,7 @@ a.skill-tag:hover {
   filter: invert(1);
 }
 
-.skill-panel__footnote {
+.panel__footnote {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -133,19 +106,19 @@ a.skill-tag:hover {
   border-top: 1px solid var(--color-border);
 }
 
-.skill-panel__footnote + .skill-panel__row--link {
+.panel__footnote + .panel__row--link {
   padding: 4px 18px 12px;
 }
 
-.skill-panel__footnote svg {
+.panel__footnote svg {
   flex-shrink: 0;
 }
 
-.skill-panel__footnote-icon {
+.panel__footnote-icon {
   flex-shrink: 0;
 }
 
-.skill-panel__row--cert {
+.panel__row--cert {
   flex-direction: row;
   align-items: center;
   gap: 16px;
@@ -153,27 +126,27 @@ a.skill-tag:hover {
   color: var(--color-text);
 }
 
-.skill-panel__row--cert:hover .skill-panel__cert-name {
+.panel__row--cert:hover .panel__cert-name {
   text-decoration: underline;
 }
 
-.skill-panel__row--link {
+.panel__row--link {
   font-size: 13px;
   color: var(--color-accent);
   text-decoration: none;
 }
 
-.skill-panel__row--link:hover {
+.panel__row--link:hover {
   text-decoration: underline;
 }
 
-.skill-panel__cert-name {
+.panel__cert-name {
   font-weight: 600;
   font-size: 14px;
   margin-bottom: 4px;
 }
 
-.skill-panel__cert-meta {
+.panel__cert-meta {
   font-size: 12px;
   color: var(--color-text-muted);
 }

--- a/src/views/Skills.tsx
+++ b/src/views/Skills.tsx
@@ -3,17 +3,18 @@ import { certifications, credlyBadgesUrl, credlySkillsUrl, leetcodeUsername } fr
 import { type SkillGroup, skillGroups } from '../data/skills';
 import { SectionHeading } from '../components/SectionHeading';
 import { LeetCodeStats } from '../components/LeetCodeStats';
+import '../components/Panel.css';
 import './Skills.css';
 
 function SkillGroupRow({ group }: { group: SkillGroup }) {
   if (group.collapsible) {
     return (
-      <details className="skill-panel__row skill-panel__row--collapsible">
-        <summary className="skill-panel__row-summary">
+      <details className="panel__row panel__row--collapsible">
+        <summary className="panel__row-summary">
           <span>{group.label}</span>
-          <span className="skill-panel__row-summary-meta mono">{group.tags.length}</span>
+          <span className="panel__row-summary-meta mono">{group.tags.length}</span>
         </summary>
-        <div className="skill-panel__tags skill-panel__tags--collapsible">
+        <div className="panel__tags panel__tags--collapsible">
           {group.tags.map((skillTag) => (
             <SkillTagPill key={skillTag.name} tag={skillTag} />
           ))}
@@ -23,9 +24,9 @@ function SkillGroupRow({ group }: { group: SkillGroup }) {
   }
 
   return (
-    <div className="skill-panel__row">
-      <span className="skill-panel__row-label">{group.label}</span>
-      <div className="skill-panel__tags">
+    <div className="panel__row">
+      <span className="panel__row-label">{group.label}</span>
+      <div className="panel__tags">
         {group.tags.map((skillTag) => (
           <SkillTagPill key={skillTag.name} tag={skillTag} />
         ))}
@@ -42,46 +43,46 @@ export function Skills() {
       </div>
 
       <div className="page__body">
-        <div className="skill-panel">
-          <div className="skill-panel__header">🛠 Skills</div>
+        <div className="panel">
+          <div className="panel__header">🛠 Skills</div>
           {skillGroups.map((group) => (
             <SkillGroupRow key={group.label} group={group} />
           ))}
-          <p className="skill-panel__footnote">
+          <p className="panel__footnote">
             <CredlyBadge inline /> Skills with this mark are verified via Credly certifications.
           </p>
-          <a className="skill-panel__row skill-panel__row--link" href={credlySkillsUrl} target="_blank" rel="noopener">
+          <a className="panel__row panel__row--link" href={credlySkillsUrl} target="_blank" rel="noopener">
             View on Credly →
           </a>
         </div>
 
-        <div className="skill-panel">
-          <div className="skill-panel__header">🏅 Certifications</div>
+        <div className="panel">
+          <div className="panel__header">🏅 Certifications</div>
           {certifications.map((cert) => (
             <a
               key={cert.url}
-              className="skill-panel__row skill-panel__row--cert"
+              className="panel__row panel__row--cert"
               href={cert.url}
               target="_blank"
               rel="noopener"
             >
               <img src={cert.image} alt={cert.name} width={80} />
               <div>
-                <div className="skill-panel__cert-name">{cert.name}</div>
-                <span className="skill-panel__cert-meta mono">
+                <div className="panel__cert-name">{cert.name}</div>
+                <span className="panel__cert-meta mono">
                   {cert.issuer} · {cert.issued}
                 </span>
               </div>
             </a>
           ))}
-          <a className="skill-panel__row skill-panel__row--link" href={credlyBadgesUrl} target="_blank" rel="noopener">
+          <a className="panel__row panel__row--link" href={credlyBadgesUrl} target="_blank" rel="noopener">
             View on Credly →
           </a>
         </div>
 
-        <div className="skill-panel">
-          <div className="skill-panel__header">🧩 LeetCode</div>
-          <div className="skill-panel__row">
+        <div className="panel">
+          <div className="panel__header">🧩 LeetCode</div>
+          <div className="panel__row">
             <LeetCodeStats username={leetcodeUsername} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- `OpenSource.tsx` imported `./Skills.css` solely to reuse `.skill-panel`/`.skill-panel__header`/`.skill-panel__row` for the CNCF Stats panel — a cross-page coupling smell
- Extracted the generic panel shell into `src/components/Panel.css` (`.panel`, `.panel__header`, `.panel__row`), imported by both `Skills.tsx` and `OpenSource.tsx`
- Renamed the remaining `skill-panel__*` classes in `Skills.css` to `panel__*` for consistent BEM naming against the shared `.panel` block (Skills-only extensions like `__tags`, `__cert-name`, `__footnote` stay in `Skills.css`)

Fixes #35.

## Test plan
- [x] `astro check` passes with 0 errors
- [x] `eslint` clean on touched files
- [x] `astro build` succeeds; verified via Playwright screenshot that Skills, Certifications, LeetCode, and Open Source's CNCF Stats panels all render with correct styling